### PR TITLE
Update Homey thermostat_mode to Off when device is turned off.

### DIFF
--- a/app.json
+++ b/app.json
@@ -267,6 +267,14 @@
                   "nl": "Alleen fans",
                   "de": "Nur Fan"
                 }
+              },
+              {
+                "id": "off",
+                "title": {
+                  "en": "Off",
+                  "nl": "Uit",
+                  "de": "Aus"
+                }
               }
             ]
           }
@@ -616,6 +624,14 @@
                   "nl": "Alleen fans",
                   "de": "Nur Fan"
                 }
+              },
+              {
+                "id": "off",
+                "title": {
+                  "en": "Off",
+                  "nl": "Uit",
+                  "de": "Aus"
+                }
               }
             ]
           }
@@ -956,6 +972,14 @@
             "en": "Fan Only",
             "nl": "Alleen fans",
             "de": "Nur Fan"
+          }
+        },
+        {
+          "id": "off",
+          "title": {
+            "en": "Off",
+            "nl": "Uit",
+            "de": "Aus"
           }
         }
       ],

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -270,11 +270,16 @@ class GreeHVACDevice extends Homey.Device {
                 }).catch(this.error);
             } else {
                 // Restore Homey thermostat mode when turned on.
-                const restoredHvacMode = properties[HVAC.PROPERTY.mode];
+                const restoredHvacMode = updatedProperties[HVAC.PROPERTY.mode] === undefined ? properties[HVAC.PROPERTY.mode] : updatedProperties[HVAC.PROPERTY.mode];
                 this.setCapabilityValue('thermostat_mode', restoredHvacMode).then(() => {
                     this.log('[update properties]', '[hvac_mode]', restoredHvacMode);
                     return this._flowTriggerHvacModeChanged.trigger(this, { hvac_mode: restoredHvacMode });
                 }).catch(this.error);
+            }
+
+            // Prevent duplicate thermostat_mode update.
+            if (updatedProperties[HVAC.PROPERTY.mode] !== undefined) {
+                delete updatedProperties[HVAC.PROPERTY.mode];
             }
         }
 

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -248,6 +248,11 @@ class GreeHVACDevice extends Homey.Device {
         if (!this.getAvailable()) {
             this.log('[update]', 'mark device available');
             this.setAvailable();
+
+            // Ensure that thermostat_mode is properly set in Homey when device becomes available.
+            if (properties[HVAC.PROPERTY.power] === HVAC.VALUE.power.off && this.getCapabilityValue('thermostat_mode') !== 'off') {
+                updatedProperties[HVAC.PROPERTY.mode] = 'off';
+            }
         }
 
         if (this._checkBoolPropertyChanged(updatedProperties, HVAC.PROPERTY.power, 'onoff')) {

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -293,7 +293,15 @@ class GreeHVACDevice extends Homey.Device {
         }
 
         if (this._checkPropertyChanged(updatedProperties, HVAC.PROPERTY.mode, 'thermostat_mode')) {
-            if (properties[HVAC.PROPERTY.power] !== HVAC.VALUE.power.off) {
+            if (properties[HVAC.PROPERTY.power] === HVAC.VALUE.power.off) {
+                // When HVAC is off, thermostat_mode should be always "off".
+                if (this.getCapabilityValue('thermostat_mode') !== 'off') {
+                    this.setCapabilityValue('thermostat_mode', 'off').then(() => {
+                        this.log('[update properties]', '[hvac_mode]', 'off');
+                        return this._flowTriggerHvacModeChanged.trigger(this, { hvac_mode: 'off' });
+                    }).catch(this.error);
+                }
+            } else {
                 const value = updatedProperties[HVAC.PROPERTY.mode];
                 this.setCapabilityValue('thermostat_mode', value).then(() => {
                     this.log('[update properties]', '[hvac_mode]', value);

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -124,6 +124,15 @@ class GreeHVACDevice extends Homey.Device {
             this.log('[power mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
             this._setClientProperty(HVAC.PROPERTY.power, rawValue);
 
+            if (rawValue === HVAC.VALUE.power.off) {
+                // Set Thermostat mode to Off.
+                this.setCapabilityValue('thermostat_mode', 'off');
+            } else {
+                // Restore thermostat_mode.
+                const properties = this._client._transformer.fromVendor(this._client._properties);
+                this.setCapabilityValue('thermostat_mode', HVAC.VALUE.mode[properties[HVAC.PROPERTY.mode]]);
+            }
+
             return Promise.resolve();
         });
 
@@ -135,10 +144,23 @@ class GreeHVACDevice extends Homey.Device {
         });
 
         this.registerCapabilityListener('thermostat_mode', value => {
-            const rawValue = HVAC.VALUE.mode[value];
-            this.log('[mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            this._flowTriggerHvacModeChanged.trigger(this, { hvac_mode: value });
-            this._setClientProperty(HVAC.PROPERTY.mode, rawValue);
+            if (value === 'off') {
+                this.log('[power mode change]', `Value: ${value}`);
+                this._setClientProperty(HVAC.PROPERTY.power, HVAC.VALUE.power.off);
+                this.setCapabilityValue('onoff', false);
+            } else {
+                const rawValue = HVAC.VALUE.mode[value];
+                this.log('[mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
+                this._flowTriggerHvacModeChanged.trigger(this, {hvac_mode: value});
+                this._setClientProperty(HVAC.PROPERTY.mode, rawValue);
+
+                // Turn on if needed.
+                const properties = this._client._transformer.fromVendor(this._client._properties);
+                if (properties[HVAC.PROPERTY.power] === HVAC.VALUE.power.off) {
+                    this.setCapabilityValue('onoff', true);
+                    this._setClientProperty(HVAC.PROPERTY.power, HVAC.VALUE.power.on);
+                }
+            }
 
             return Promise.resolve();
         });
@@ -234,6 +256,21 @@ class GreeHVACDevice extends Homey.Device {
                 this.log('[update properties]', '[onoff]', value);
                 return Promise.resolve();
             }).catch(this.error);
+
+            if (!value) {
+                // Set Homey thermostat mode to Off when turned off.
+                this.setCapabilityValue('thermostat_mode', 'off').then(() => {
+                    this.log('[update properties]', '[hvac_mode]', 'off');
+                    return this._flowTriggerHvacModeChanged.trigger(this, { hvac_mode: 'off' });
+                }).catch(this.error);
+            } else {
+                // Restore Homey thermostat mode when turned on.
+                const restoredHvacMode = properties[HVAC.PROPERTY.mode];
+                this.setCapabilityValue('thermostat_mode', restoredHvacMode).then(() => {
+                    this.log('[update properties]', '[hvac_mode]', restoredHvacMode);
+                    return this._flowTriggerHvacModeChanged.trigger(this, { hvac_mode: restoredHvacMode });
+                }).catch(this.error);
+            }
         }
 
         if (this._checkPropertyChanged(updatedProperties, HVAC.PROPERTY.temperature, 'target_temperature')) {
@@ -256,11 +293,13 @@ class GreeHVACDevice extends Homey.Device {
         }
 
         if (this._checkPropertyChanged(updatedProperties, HVAC.PROPERTY.mode, 'thermostat_mode')) {
-            const value = updatedProperties[HVAC.PROPERTY.mode];
-            this.setCapabilityValue('thermostat_mode', value).then(() => {
-                this.log('[update properties]', '[hvac_mode]', value);
-                return this._flowTriggerHvacModeChanged.trigger(this, { hvac_mode: value });
-            }).catch(this.error);
+            if (properties[HVAC.PROPERTY.power] !== HVAC.VALUE.power.off) {
+                const value = updatedProperties[HVAC.PROPERTY.mode];
+                this.setCapabilityValue('thermostat_mode', value).then(() => {
+                    this.log('[update properties]', '[hvac_mode]', value);
+                    return this._flowTriggerHvacModeChanged.trigger(this, { hvac_mode: value });
+                }).catch(this.error);
+            }
         }
 
         if (this._checkPropertyChanged(updatedProperties, HVAC.PROPERTY.fanSpeed, 'fan_speed')) {


### PR DESCRIPTION
Homey for thermostat_mode capability has mode "off" which should be used when HVAC is turned off. 
https://apps-sdk-v3.developer.homey.app/tutorial-device-capabilities.html

At this moment integration is not updating thermostat_mode when device is turned on/off. This is a problem in HomeKit integration, as HVACs are exposed only as Thermostat.

Because of that HVAC is visible as constantly turned on/off in HomeKit. HomeKit "off" mode is not working correctly - you are unable to turn off HVAC (or turn on via HomeKit if HVAC is turned off).  

Please let me know if I should do anything here :) 

This is fix for problem reported by me: https://community.homey.app/t/app-pro-gree-hvac-app/30801/47?u=n3o 