### PR TITLE
Update gree-hvac-client

### DIFF
--- a/drivers/gree_cooper_hunter_hvac/network/finder.js
+++ b/drivers/gree_cooper_hunter_hvac/network/finder.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const dgram = require('dgram');
-const { EncryptionService } = require('gree-hvac-client/lib/encryption-service');
+const { EncryptionService } = require('gree-hvac-client/src/encryption-service');
 
 const SCAN_MESSAGE = Buffer.from('{"t": "scan"}');
 const THIRTY_SECONDS = 30 * 1000;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "gree-hvac-client": "git+https://github.com/aivus/gree-hvac-client.git#com.gree/master",
+        "gree-hvac-client": "github:aivus/gree-hvac-client#com.gree/master",
         "homey-log": "^2.1.0"
       },
       "devDependencies": {
@@ -3374,10 +3374,9 @@
       "dev": true
     },
     "node_modules/gree-hvac-client": {
-      "version": "1.3.1",
-      "resolved": "git+ssh://git@github.com/aivus/gree-hvac-client.git#0a83781903fad1fc54f1f2fa87d4c6af21e75641",
-      "integrity": "sha512-L3Zp1BVPBVLpKxul5L9NnW0XC7oy73vmURAcMa1Srw/BauIPlqiwKj7TYwUtl35iF8bVhptNaz/zpnVSm6oxBQ==",
-      "license": "MIT",
+      "version": "0.0.0-development",
+      "resolved": "git+ssh://git@github.com/aivus/gree-hvac-client.git#5607ac8fd288e0e2060c13701178cb6a0b1bf3bf",
+      "license": "GPL-3.0",
       "dependencies": {
         "clone": "^2.1.2",
         "object-diff": "^0.0.4"
@@ -10239,9 +10238,8 @@
       "dev": true
     },
     "gree-hvac-client": {
-      "version": "git+ssh://git@github.com/aivus/gree-hvac-client.git#0a83781903fad1fc54f1f2fa87d4c6af21e75641",
-      "integrity": "sha512-L3Zp1BVPBVLpKxul5L9NnW0XC7oy73vmURAcMa1Srw/BauIPlqiwKj7TYwUtl35iF8bVhptNaz/zpnVSm6oxBQ==",
-      "from": "gree-hvac-client@git+https://github.com/aivus/gree-hvac-client.git#com.gree/master",
+      "version": "git+ssh://git@github.com/aivus/gree-hvac-client.git#5607ac8fd288e0e2060c13701178cb6a0b1bf3bf",
+      "from": "gree-hvac-client@github:aivus/gree-hvac-client#com.gree/master",
       "requires": {
         "clone": "^2.1.2",
         "object-diff": "^0.0.4"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/aivus/com.gree#readme",
   "dependencies": {
-    "gree-hvac-client": "git+https://github.com/aivus/gree-hvac-client.git#com.gree/master",
+    "gree-hvac-client": "github:aivus/gree-hvac-client#com.gree/master",
     "homey-log": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Seems we can re-create [`com.gree/master`](https://github.com/aivus/gree-hvac-client/tree/com.gree/master) branch from the upstream repo