### PR TITLE
Use built-in "thermostat_mode" for HVAC mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,56 +11,63 @@ class GreeHVAC extends Homey.App {
         this.log('Gree HVAC app is up and running...');
 
         // Register conditions for flows
-        this._conditionHVACModeIs = this.homey.flow.getConditionCard('hvac_mode_is')
+        this.homey.flow.getConditionCard('hvac_mode_is')
             .registerRunListener((args, state) => {
                 const hvacMode = args.device.getCapabilityValue('thermostat_mode');
                 args.device.log('[condition]', '[current hvac mode]', hvacMode);
                 return args.mode === hvacMode;
             });
 
-        this._conditionFanSpeedIs = this.homey.flow.getConditionCard('fan_speed_is')
+        this.homey.flow.getConditionCard('thermostat_mode_is')
+            .registerRunListener((args, state) => {
+                const hvacMode = args.device.getCapabilityValue('thermostat_mode');
+                args.device.log('[condition]', '[current thermostat mode]', hvacMode);
+                return args.thermostat_mode === hvacMode;
+            });
+
+        this.homey.flow.getConditionCard('fan_speed_is')
             .registerRunListener((args, state) => {
                 const fanSpeed = args.device.getCapabilityValue('fan_speed');
                 args.device.log('[condition]', '[current fan speed]', fanSpeed);
                 return args.speed === fanSpeed;
             });
 
-        this._conditionTurboModeIs = this.homey.flow.getConditionCard('turbo_mode_is')
+        this.homey.flow.getConditionCard('turbo_mode_is')
             .registerRunListener((args, state) => {
                 const turboMode = args.device.getCapabilityValue('turbo_mode');
                 args.device.log('[condition]', '[current turbo mode]', turboMode);
                 return onoffToBoolean(args.mode) === turboMode;
             });
 
-        this._conditionLightsIs = this.homey.flow.getConditionCard('lights_is')
+        this.homey.flow.getConditionCard('lights_is')
             .registerRunListener((args, state) => {
                 const lightsMode = args.device.getCapabilityValue('lights');
                 args.device.log('[condition]', '[current lights]', lightsMode);
                 return onoffToBoolean(args.mode) === lightsMode;
             });
 
-        this._conditionXFanModeIs = this.homey.flow.getConditionCard('xfan_mode_is')
+        this.homey.flow.getConditionCard('xfan_mode_is')
             .registerRunListener((args, state) => {
                 const xfanMode = args.device.getCapabilityValue('xfan_mode');
                 args.device.log('[condition]', '[current xfan mode]', xfanMode);
                 return onoffToBoolean(args.mode) === xfanMode;
             });
 
-        this._conditionVerticalSwingIs = this.homey.flow.getConditionCard('vertical_swing_is')
+        this.homey.flow.getConditionCard('vertical_swing_is')
             .registerRunListener((args, state) => {
                 const verticalSwing = args.device.getCapabilityValue('vertical_swing');
                 args.device.log('[condition]', '[current swing vertical]', verticalSwing);
                 return args.vertical_swing === verticalSwing;
             });
 
-        this._conditionHorizontalSwingIs = this.homey.flow.getConditionCard('horizontal_swing_is')
+        this.homey.flow.getConditionCard('horizontal_swing_is')
             .registerRunListener((args, state) => {
                 const horizontalSwing = args.device.getCapabilityValue('horizontal_swing');
                 args.device.log('[condition]', '[current swing horizontal]', horizontalSwing);
                 return args.horizontal_swing === horizontalSwing;
             });
 
-        this._conditionQuietModeIs = this.homey.flow.getConditionCard('quiet_mode_is')
+        this.homey.flow.getConditionCard('quiet_mode_is')
             .registerRunListener((args, state) => {
                 const quietMode = args.device.getCapabilityValue('quiet_mode_is');
                 args.device.log('[condition]', '[quiet mode]', quietMode);
@@ -68,56 +75,56 @@ class GreeHVAC extends Homey.App {
             });
 
         // Register actions for flows
-        this._actionChangeHVACMode = this.homey.flow.getActionCard('set_hvac_mode')
+        this.homey.flow.getActionCard('set_hvac_mode')
             .registerRunListener((args, state) => {
                 return args.device.setCapabilityValue('thermostat_mode', args.mode).then(() => {
                     return args.device.triggerCapabilityListener('thermostat_mode', args.mode, {});
                 });
             });
 
-        this._actionChangeFanSpeed = this.homey.flow.getActionCard('set_fan_speed')
+        this.homey.flow.getActionCard('set_fan_speed')
             .registerRunListener((args, state) => {
                 return args.device.setCapabilityValue('fan_speed', args.speed).then(() => {
                     return args.device.triggerCapabilityListener('fan_speed', args.speed, {});
                 });
             });
 
-        this._actionChangeTurboMode = this.homey.flow.getActionCard('set_turbo_mode')
+        this.homey.flow.getActionCard('set_turbo_mode')
             .registerRunListener((args, state) => {
                 return args.device.setCapabilityValue('turbo_mode', onoffToBoolean(args.mode)).then(() => {
                     return args.device.triggerCapabilityListener('turbo_mode', onoffToBoolean(args.mode), {});
                 });
             });
 
-        this._actionChangeLights = this.homey.flow.getActionCard('set_lights')
+        this.homey.flow.getActionCard('set_lights')
             .registerRunListener((args, state) => {
                 return args.device.setCapabilityValue('lights', onoffToBoolean(args.mode)).then(() => {
                     return args.device.triggerCapabilityListener('lights', onoffToBoolean(args.mode), {});
                 });
             });
 
-        this._actionChangeXFanMode = this.homey.flow.getActionCard('set_xfan_mode')
+        this.homey.flow.getActionCard('set_xfan_mode')
             .registerRunListener((args, state) => {
                 return args.device.setCapabilityValue('xfan_mode', onoffToBoolean(args.mode)).then(() => {
                     return args.device.triggerCapabilityListener('xfan_mode', onoffToBoolean(args.mode), {});
                 });
             });
 
-        this._actionChangeVerticalSwing = this.homey.flow.getActionCard('set_vertical_swing')
+        this.homey.flow.getActionCard('set_vertical_swing')
             .registerRunListener((args, state) => {
                 return args.device.setCapabilityValue('vertical_swing', args.vertical_swing).then(() => {
                     return args.device.triggerCapabilityListener('vertical_swing', args.vertical_swing, {});
                 });
             });
 
-        this._actionChangeHorizontalSwing = this.homey.flow.getActionCard('set_horizontal_swing')
+        this.homey.flow.getActionCard('set_horizontal_swing')
             .registerRunListener((args, state) => {
                 return args.device.setCapabilityValue('horizontal_swing', args.horizontal_swing).then(() => {
                     return args.device.triggerCapabilityListener('horizontal_swing', args.horizontal_swing, {});
                 });
             });
 
-        this._actionChangeQuietMode = this.homey.flow.getActionCard('set_quiet_mode')
+        this.homey.flow.getActionCard('set_quiet_mode')
             .registerRunListener((args, state) => {
                 return args.device.setCapabilityValue('quiet_mode', args.mode).then(() => {
                     return args.device.triggerCapabilityListener('quiet_mode', args.mode, {});

--- a/app.js
+++ b/app.js
@@ -13,7 +13,7 @@ class GreeHVAC extends Homey.App {
         // Register conditions for flows
         this._conditionHVACModeIs = this.homey.flow.getConditionCard('hvac_mode_is')
             .registerRunListener((args, state) => {
-                const hvacMode = args.device.getCapabilityValue('hvac_mode');
+                const hvacMode = args.device.getCapabilityValue('thermostat_mode');
                 args.device.log('[condition]', '[current hvac mode]', hvacMode);
                 return args.mode === hvacMode;
             });
@@ -70,8 +70,8 @@ class GreeHVAC extends Homey.App {
         // Register actions for flows
         this._actionChangeHVACMode = this.homey.flow.getActionCard('set_hvac_mode')
             .registerRunListener((args, state) => {
-                return args.device.setCapabilityValue('hvac_mode', args.mode).then(() => {
-                    return args.device.triggerCapabilityListener('hvac_mode', args.mode, {});
+                return args.device.setCapabilityValue('thermostat_mode', args.mode).then(() => {
+                    return args.device.triggerCapabilityListener('thermostat_mode', args.mode, {});
                 });
             });
 

--- a/app.js
+++ b/app.js
@@ -18,13 +18,6 @@ class GreeHVAC extends Homey.App {
                 return args.mode === hvacMode;
             });
 
-        this.homey.flow.getConditionCard('thermostat_mode_is')
-            .registerRunListener((args, state) => {
-                const hvacMode = args.device.getCapabilityValue('thermostat_mode');
-                args.device.log('[condition]', '[current thermostat mode]', hvacMode);
-                return args.thermostat_mode === hvacMode;
-            });
-
         this.homey.flow.getConditionCard('fan_speed_is')
             .registerRunListener((args, state) => {
                 const fanSpeed = args.device.getCapabilityValue('fan_speed');

--- a/app.json
+++ b/app.json
@@ -1,11 +1,11 @@
 {
-  "id": "com.gree",
-  "version": "0.8.0",
-  "compatibility": ">=5.0.0",
+  "id": "com.gree.test",
+  "version": "0.8.1",
+  "compatibility": ">=12.0.1",
   "sdk": 3,
   "brandColor": "#ff732e",
   "name": {
-    "en": "Gree"
+    "en": "Gree (test)"
   },
   "description": {
     "en": "Control your Gree and other EWPE Smart compatible HVAC devices",
@@ -1254,64 +1254,6 @@
     ]
   },
   "capabilities": {
-    "hvac_mode": {
-      "type": "enum",
-      "title": {
-        "en": "HVAC mode",
-        "nl": "HVAC modus",
-        "de": "HVAC-Modus"
-      },
-      "desc": {
-        "en": "Mode of the HVAC",
-        "nl": "Modus van de HVAC",
-        "de": "Modus der HVAC"
-      },
-      "values": [
-        {
-          "id": "auto",
-          "title": {
-            "en": "Auto",
-            "nl": "Automatisch",
-            "de": "Automatisch"
-          }
-        },
-        {
-          "id": "cool",
-          "title": {
-            "en": "Cool",
-            "nl": "Koelen",
-            "de": "Kühlen"
-          }
-        },
-        {
-          "id": "heat",
-          "title": {
-            "en": "Heat",
-            "nl": "Verwarmen",
-            "de": "Heizen"
-          }
-        },
-        {
-          "id": "dry",
-          "title": {
-            "en": "Dry",
-            "nl": "Ontvochtigen",
-            "de": "Trocken"
-          }
-        },
-        {
-          "id": "fan_only",
-          "title": {
-            "en": "Fan Only",
-            "nl": "Alleen fans",
-            "de": "Nur Fan"
-          }
-        }
-      ],
-      "getable": true,
-      "setable": true,
-      "uiComponent": "picker"
-    },
     "fan_speed": {
       "type": "enum",
       "title": {
@@ -1669,7 +1611,6 @@
         "measure_temperature",
         "target_temperature",
         "thermostat_mode",
-        "hvac_mode",
         "fan_speed",
         "turbo_mode",
         "lights",
@@ -1683,6 +1624,55 @@
           "min": 16,
           "max": 30,
           "step": 1
+        },
+        "thermostat_mode": {
+          "title": {
+            "en": "HVAC mode",
+            "nl": "HVAC modus",
+            "de": "HVAC-Modus"
+          },
+          "values": [
+            {
+              "id": "auto",
+              "title": {
+                "en": "Auto",
+                "nl": "Automatisch",
+                "de": "Automatisch"
+              }
+            },
+            {
+              "id": "cool",
+              "title": {
+                "en": "Cool",
+                "nl": "Koelen",
+                "de": "Kühlen"
+              }
+            },
+            {
+              "id": "heat",
+              "title": {
+                "en": "Heat",
+                "nl": "Verwarmen",
+                "de": "Heizen"
+              }
+            },
+            {
+              "id": "dry",
+              "title": {
+                "en": "Dry",
+                "nl": "Ontvochtigen",
+                "de": "Trocken"
+              }
+            },
+            {
+              "id": "fan_only",
+              "title": {
+                "en": "Fan Only",
+                "nl": "Alleen fans",
+                "de": "Nur Fan"
+              }
+            }
+          ]
         }
       },
       "pair": [

--- a/app.json
+++ b/app.json
@@ -1,11 +1,11 @@
 {
-  "id": "com.gree.test",
+  "id": "com.gree",
   "version": "0.8.1",
   "compatibility": ">=12.0.1",
   "sdk": 3,
   "brandColor": "#ff732e",
   "name": {
-    "en": "Gree (test)"
+    "en": "Gree"
   },
   "description": {
     "en": "Control your Gree and other EWPE Smart compatible HVAC devices",

--- a/app.json
+++ b/app.json
@@ -90,6 +90,7 @@
       },
       {
         "id": "hvac_mode_changed",
+        "deprecated": true,
         "title": {
           "en": "HVAC mode changed"
         },
@@ -267,6 +268,7 @@
     "conditions": [
       {
         "id": "hvac_mode_is",
+        "deprecated": true,
         "title": {
           "en": "Current HVAC mode !{{is|isn't}} ..."
         },
@@ -765,6 +767,7 @@
     "actions": [
       {
         "id": "set_hvac_mode",
+        "deprecated": true,
         "title": {
           "en": "Set HVAC mode",
           "nl": "Stel de HVAC-modus in",

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -278,24 +278,24 @@ class GreeHVACDevice extends Homey.Device {
         }
 
         if (this._checkBoolPropertyChanged(updatedProperties, HVAC.PROPERTY.power, 'onoff')) {
-            const value = updatedProperties[HVAC.PROPERTY.power] === HVAC.VALUE.power.on;
-            this.setCapabilityValue('onoff', value).then(() => {
-                this.log('[update properties]', '[onoff]', value);
+            const isOn = updatedProperties[HVAC.PROPERTY.power] === HVAC.VALUE.power.on;
+            this.setCapabilityValue('onoff', isOn).then(() => {
+                this.log('[update properties]', '[onoff]', isOn);
                 return Promise.resolve();
             }).catch(this.error);
 
-            if (!value) {
+            if (!isOn) {
                 // Set Homey thermostat mode to Off when turned off.
                 this.setCapabilityValue('thermostat_mode', 'off').then(() => {
                     this.log('[update properties]', '[thermostat_mode]', 'off');
                 }).catch(this.error);
             } else {
                 // Restore Homey thermostat mode when turned on.
-                const restoredHvacMode = updatedProperties[HVAC.PROPERTY.mode] === undefined ? properties[HVAC.PROPERTY.mode] : updatedProperties[HVAC.PROPERTY.mode];
+                const thermostatValue = properties[HVAC.PROPERTY.mode];
 
-                this.setCapabilityValue('thermostat_mode', restoredHvacMode).then(() => {
-                    this.log('[update properties]', '[thermostat_mode]', restoredHvacMode);
-                    return this._flowTriggerHvacModeChanged.trigger(this, { hvac_mode: restoredHvacMode });
+                this.setCapabilityValue('thermostat_mode', thermostatValue).then(() => {
+                    this.log('[update properties]', '[thermostat_mode]', thermostatValue);
+                    return this._flowTriggerHvacModeChanged.trigger(this, { hvac_mode: thermostatValue });
                 }).catch(this.error);
             }
 

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -47,7 +47,7 @@ class GreeHVACDevice extends Homey.Device {
         await this._executeCapabilityMigrations();
         this._registerCapabilityListeners();
 
-        this._markOffline();
+        // this._markOffline();
         this._startLookingForDevice();
     }
 
@@ -154,7 +154,6 @@ class GreeHVACDevice extends Homey.Device {
                 const rawValue = HVAC.VALUE.mode[value];
                 this.log('[thermostat_mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
                 this._setClientProperty(HVAC.PROPERTY.mode, rawValue);
-                this.setCapabilityValue('hvac_mode', rawValue);
 
                 // Turn on if needed.
                 const properties = this._client._transformer.fromVendor(this._client._properties);
@@ -162,27 +161,6 @@ class GreeHVACDevice extends Homey.Device {
                     this.setCapabilityValue('onoff', true);
                     this._setClientProperty(HVAC.PROPERTY.power, HVAC.VALUE.power.on);
                 }
-            }
-
-            return Promise.resolve();
-        });
-
-        this.registerCapabilityListener('hvac_mode', (value) => {
-            let rawValue = HVAC.VALUE.mode[value];
-            this.log('[hvac_mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            this._setClientProperty(HVAC.PROPERTY.mode, rawValue);
-            this._flowTriggerHvacModeChanged.trigger(this, { hvac_mode: rawValue });
-
-            // Update thermostat_mode when on
-            if (this.getCapabilityValue('onoff') === true) {
-                // Homey doesn't support fan_only or dry
-                if (rawValue === 'fan_only') {
-                    rawValue = 'off';
-                } else if (value === 'dry') {
-                    rawValue = 'cool';
-                }
-
-                this.setCapabilityValue('thermostat_mode', rawValue);
             }
 
             return Promise.resolve();
@@ -313,22 +291,11 @@ class GreeHVACDevice extends Homey.Device {
                 }).catch(this.error);
             } else {
                 // Restore Homey thermostat mode when turned on.
-                let restoredHvacMode = updatedProperties[HVAC.PROPERTY.mode] === undefined ? properties[HVAC.PROPERTY.mode] : updatedProperties[HVAC.PROPERTY.mode];
-
-                this.setCapabilityValue('hvac_mode', restoredHvacMode).then(() => {
-                    this.log('[update properties]', '[hvac_mode]', restoredHvacMode);
-                    return this._flowTriggerHvacModeChanged.trigger(this, { hvac_mode: restoredHvacMode });
-                }).catch(this.error);
-
-                // Homey thermostat doesn't support fan_only or dry
-                if (restoredHvacMode === 'fan_only') {
-                    restoredHvacMode = 'off';
-                } else if (restoredHvacMode === 'dry') {
-                    restoredHvacMode = 'cool';
-                }
+                const restoredHvacMode = updatedProperties[HVAC.PROPERTY.mode] === undefined ? properties[HVAC.PROPERTY.mode] : updatedProperties[HVAC.PROPERTY.mode];
 
                 this.setCapabilityValue('thermostat_mode', restoredHvacMode).then(() => {
                     this.log('[update properties]', '[thermostat_mode]', restoredHvacMode);
+                    return this._flowTriggerHvacModeChanged.trigger(this, { hvac_mode: restoredHvacMode });
                 }).catch(this.error);
             }
 
@@ -357,9 +324,7 @@ class GreeHVACDevice extends Homey.Device {
             }).catch(this.error);
         }
 
-        if (this._checkPropertyChanged(updatedProperties, HVAC.PROPERTY.mode, 'hvac_mode')) {
-            const value = updatedProperties[HVAC.PROPERTY.mode];
-
+        if (this._checkPropertyChanged(updatedProperties, HVAC.PROPERTY.mode, 'thermostat_mode')) {
             // Update thermostat_mode
             if (properties[HVAC.PROPERTY.power] === HVAC.VALUE.power.off) {
                 // When HVAC is off, thermostat_mode should be always "off".
@@ -369,24 +334,13 @@ class GreeHVACDevice extends Homey.Device {
                     }).catch(this.error);
                 }
             } else {
-                let thermostatValue = updatedProperties[HVAC.PROPERTY.mode];
-
-                // Homey doesn't support fan_only or dry
-                if (thermostatValue === 'fan_only') {
-                    thermostatValue = 'off';
-                } else if (value === 'dry') {
-                    thermostatValue = 'cool';
-                }
+                const thermostatValue = updatedProperties[HVAC.PROPERTY.mode];
 
                 this.setCapabilityValue('thermostat_mode', thermostatValue).then(() => {
                     this.log('[update properties]', '[thermostat_mode]', thermostatValue);
+                    return this._flowTriggerHvacModeChanged.trigger(this, { hvac_mode: thermostatValue });
                 }).catch(this.error);
             }
-
-            this.setCapabilityValue('hvac_mode', value).then(() => {
-                this.log('[update properties]', '[hvac_mode]', value);
-                return this._flowTriggerHvacModeChanged.trigger(this, { hvac_mode: value });
-            }).catch(this.error);
         }
 
         if (this._checkPropertyChanged(updatedProperties, HVAC.PROPERTY.fanSpeed, 'fan_speed')) {
@@ -594,55 +548,71 @@ class GreeHVACDevice extends Homey.Device {
     async _executeCapabilityMigrations() {
         // Added in v0.2.1
         if (!this.hasCapability('turbo_mode')) {
-            this.log('[migration]', 'Adding "turbo_mode" capability');
+            this.log('[migration v0.2.1]', 'Adding "turbo_mode" capability');
             await this.addCapability('turbo_mode');
         }
 
-        // Added in v0.2.1
         if (!this.hasCapability('lights')) {
-            this.log('[migration]', 'Adding "lights" capability');
+            this.log('[migration v0.2.1]', 'Adding "lights" capability');
             await this.addCapability('lights');
         }
 
         // Added in v0.3.0
         if (!this.hasCapability('xfan_mode')) {
-            this.log('[migration]', 'Adding "xfan_mode" capability');
+            this.log('[migration v0.3.0]', 'Adding "xfan_mode" capability');
             await this.addCapability('xfan_mode');
         }
 
         // Added in v0.3.0
         if (!this.hasCapability('vertical_swing')) {
-            this.log('[migration]', 'Adding "vertical_swing" capability');
+            this.log('[migration v0.3.0]', 'Adding "vertical_swing" capability');
             await this.addCapability('vertical_swing');
         }
 
         // Added in v0.4.0
         if (!this.hasCapability('measure_temperature')) {
-            this.log('[migration]', 'Adding "measure_temperature" capability');
+            this.log('[migration v0.4.0]', 'Adding "measure_temperature" capability');
             await this.addCapability('measure_temperature');
         }
 
         // Added in v0.5.0
         if (!this.hasCapability('thermostat_mode') && this.hasCapability('hvac_mode')) {
-            this.log('[migration]', 'Converting "hvac_mode" to "thermostat_mode"');
+            this.log('[migration v0.5.0]', 'Converting "hvac_mode" to "thermostat_mode"');
             await this.removeCapability('hvac_mode');
             await this.addCapability('thermostat_mode');
         }
 
-        // Added in v0.8.0
+        // Added in v0.8.0 (test)
         if (!this.hasCapability('horizontal_swing')) {
-            this.log('[migration]', 'Adding "horizontal_swing" capability');
+            this.log('[migration v0.8.0]', 'Adding "horizontal_swing" capability');
             await this.addCapability('horizontal_swing');
         }
 
         if (!this.hasCapability('quiet_mode')) {
-            this.log('[migration]', 'Adding "quiet_mode" capability');
+            this.log('[migration v0.8.0]', 'Adding "quiet_mode" capability');
             await this.addCapability('quiet_mode');
         }
 
-        if (!this.hasCapability('hvac_mode')) {
-            this.log('[migration]', 'Adding "hvac_mode" capability');
-            await this.addCapability('hvac_mode');
+        // Commented in v0.8.1
+        // if (!this.hasCapability('hvac_mode')) {
+        //     this.log('[migration]', 'Adding "hvac_mode" capability');
+        //     await this.addCapability('hvac_mode');
+        // }
+
+        // Added in v0.8.1
+        // Revert back from "hvac_mode" to "thermostat_mode"
+        if (this.hasCapability('hvac_mode')) {
+            this.log('[migration v0.8.1]', 'Removing "hvac_mode" capability');
+            await this.removeCapability('hvac_mode');
+
+            // Re-add thermostat_mode with new configuration
+            if (this.hasCapability('thermostat_mode')) {
+                this.log('[migration v0.8.1]', 'Removing "thermostat_mode" capability');
+                await this.removeCapability('thermostat_mode');
+            }
+
+            this.log('[migration v0.8.1]', 'Adding "thermostat_mode" capability');
+            await this.addCapability('thermostat_mode');
         }
     }
 

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -47,7 +47,7 @@ class GreeHVACDevice extends Homey.Device {
         await this._executeCapabilityMigrations();
         this._registerCapabilityListeners();
 
-        // this._markOffline();
+        this._markOffline();
         this._startLookingForDevice();
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "homey-log": "^2.1.0"
       },
       "devDependencies": {
-        "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.1",
+        "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.7",
         "eslint": "^7.32.0",
         "eslint-config-athom": "^3.1.1",
         "homey": "^3.6.2"
@@ -236,9 +236,9 @@
     },
     "node_modules/@types/homey": {
       "name": "homey-apps-sdk-v3-types",
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/homey-apps-sdk-v3-types/-/homey-apps-sdk-v3-types-0.3.6.tgz",
-      "integrity": "sha512-uUeIE+KUBH7tQkzscpVCdq1tlCf0mL/IyL1Vu5XCs2x2dkHSIkexjXDHjhqweYT5HWPfjZZNOxMGoo7NzFjrPA==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/homey-apps-sdk-v3-types/-/homey-apps-sdk-v3-types-0.3.7.tgz",
+      "integrity": "sha512-E4Vcfew9/snrJkyog2Z+0xTZCakc55VM0j89jR5z6dkDB0HZdiU2D3kt2R+x19Wt1IFBLaYiBEztASPNCYXJuw==",
       "dev": true,
       "dependencies": {
         "@types/node": "^14.14.20"
@@ -7883,9 +7883,9 @@
       }
     },
     "@types/homey": {
-      "version": "npm:homey-apps-sdk-v3-types@0.3.6",
-      "resolved": "https://registry.npmjs.org/homey-apps-sdk-v3-types/-/homey-apps-sdk-v3-types-0.3.6.tgz",
-      "integrity": "sha512-uUeIE+KUBH7tQkzscpVCdq1tlCf0mL/IyL1Vu5XCs2x2dkHSIkexjXDHjhqweYT5HWPfjZZNOxMGoo7NzFjrPA==",
+      "version": "npm:homey-apps-sdk-v3-types@0.3.7",
+      "resolved": "https://registry.npmjs.org/homey-apps-sdk-v3-types/-/homey-apps-sdk-v3-types-0.3.7.tgz",
+      "integrity": "sha512-E4Vcfew9/snrJkyog2Z+0xTZCakc55VM0j89jR5z6dkDB0HZdiU2D3kt2R+x19Wt1IFBLaYiBEztASPNCYXJuw==",
       "dev": true,
       "requires": {
         "@types/node": "^14.14.20"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "homey-log": "^2.1.0"
   },
   "devDependencies": {
-    "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.1",
+    "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.7",
     "eslint": "^7.32.0",
     "eslint-config-athom": "^3.1.1",
     "homey": "^3.6.2"


### PR DESCRIPTION
Revert changes related to `hvac_mode` (added in #129) and use [capability options](https://apps.developer.homey.app/the-basics/devices/capabilities#enum-capability-options) for built-in `thermostat_mode`