### PR TITLE
Switch "gree-hvac-client" library to the maintained fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "gree-hvac-client": "^2.2.0",
+        "gree-hvac-client": "github:apachler/gree-hvac-client#v3.0.3",
         "homey-log": "^2.1.2"
       },
       "devDependencies": {
@@ -5297,9 +5297,8 @@
       "license": "MIT"
     },
     "node_modules/gree-hvac-client": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/gree-hvac-client/-/gree-hvac-client-2.2.0.tgz",
-      "integrity": "sha512-ebJr1YbIqNyjKeb1SgjaifdbJXHT15ZEg9SiekhhnfbMC1+921CD36l768G/vd80Q84Mm/qzuvnPYRd8VJtaxw==",
+      "version": "3.0.3",
+      "resolved": "git+ssh://git@github.com/apachler/gree-hvac-client.git#7820aa8e00c9ea6d8be8c93c89cdd8b6df428d68",
       "license": "GPL-3.0",
       "dependencies": {
         "clone": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/aivus/com.gree#readme",
   "dependencies": {
-    "gree-hvac-client": "^2.2.0",
+    "gree-hvac-client": "github:apachler/gree-hvac-client#v3.0.3",
     "homey-log": "^2.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Switch the `gree-hvac-client` dependency to the maintained fork https://github.com/apachler/gree-hvac-client