### PR TITLE
Handle nullable quite mode value argument

### DIFF
--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -279,6 +279,10 @@ class GreeHVACDevice extends Homey.Device {
         });
 
         this.registerCapabilityListener('quiet_mode', (value) => {
+            if (value === null) {
+                this.log('[quiet mode change]', 'Skip null value');
+                return Promise.resolve();
+            }
             const rawValue = HVAC.VALUE.quiet[value];
             this.log('[quiet mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
             this._setClientProperty(HVAC.PROPERTY.quiet, rawValue);

--- a/test/device.quietMode.test.js
+++ b/test/device.quietMode.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+describe('GreeHVACDevice quiet_mode listener', () => {
+    let GreeHVACDevice;
+    let device;
+    let capabilityListeners;
+
+    beforeEach(() => {
+        jest.resetModules();
+
+        capabilityListeners = {};
+
+        jest.doMock('../drivers/gree_cooper_hunter_hvac/network/finder', () => ({ hvacs: [] }));
+
+        jest.doMock('gree-hvac-client', () => ({
+            PROPERTY: { quiet: 'quiet' },
+            VALUE: {
+                quiet: {
+                    off: 'off',
+                    mode1: 'mode1',
+                    mode2: 'mode2',
+                    mode3: 'mode3',
+                },
+            },
+        }));
+
+        jest.doMock('homey', () => ({
+            Device: class Device {
+                log() {}
+                error() {}
+            },
+        }));
+
+        GreeHVACDevice = require('../drivers/gree_cooper_hunter_hvac/device');
+
+        device = new GreeHVACDevice();
+        device.registerCapabilityListener = jest.fn((capability, listener) => {
+            capabilityListeners[capability] = listener;
+        });
+        device._setClientProperty = jest.fn();
+        device._flowTriggerQuietModeChanged = {
+            trigger: jest.fn(),
+        };
+        device.log = jest.fn();
+    });
+
+    test('skips null quiet mode values', async () => {
+        device._registerCapabilityListeners();
+
+        await capabilityListeners.quiet_mode(null);
+
+        expect(device.log).toHaveBeenCalledWith('[quiet mode change]', 'Skip null value');
+        expect(device._setClientProperty).not.toHaveBeenCalled();
+        expect(device._flowTriggerQuietModeChanged.trigger).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Handle nullable value passed to quite mode capability trigger

```
Error: Could not trigger Flow card with id "quiet_mode_changed": Invalid value for token quiet_mode. Expected string but got object
    at FlowCardTriggerDevice.trigger (/app/packages/homey-local/lib/AppProcess/node_modules/@athombv/homey-apps-sdk-v3/lib/FlowCardTriggerDevice.js:58:17)
    at null.<anonymous> (/app/drivers/gree_cooper_hunter_hvac/device.js:245:47)
    at GreeHVACDevice.triggerCapabilityListener (/app/packages/homey-local/lib/AppProcess/node_modules/@athombv/homey-apps-sdk-v3/lib/Device.js:740:11)
    at null.<anonymous> (/app/app.js:151:44)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
```

from logs:
```
[quiet mode change] Value: null Raw value: undefined
```