### PR TITLE
Add "Health" (Cold plasma) mode support

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -110,5 +110,8 @@
   },
   "0.12.0": {
     "en": "Improve stability of the app"
+  },
+  "0.13.0": {
+    "en": "Add support of \"Health\" (Cold plasma) mode"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.gree",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "compatibility": ">=12.0.1",
   "sdk": 3,
   "brandColor": "#ff732e",

--- a/.homeycompose/capabilities/health_mode.json
+++ b/.homeycompose/capabilities/health_mode.json
@@ -1,0 +1,16 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "Health mode",
+    "nl": "Gezondheidsmodus",
+    "de": "Gesundheitsmodus"
+  },
+  "desc": {
+    "en": "Cold plasma / ionizer air purification mode of the HVAC",
+    "nl": "Koud plasma / ionisator luchtreinigingsmodus van de HVAC",
+    "de": "Kaltplasma- / Ionisator-Luftreinigungsmodus der Klimaanlage"
+  },
+  "getable": true,
+  "setable": true,
+  "uiComponent": "toggle"
+}

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ That means you need to turn it on manually when switch to Dry/Cool mode if you w
 ### Vertical swing
 "Disabled"/"Default" position means that vertical swing will be stopped and left on the current position.
 
+### Health mode
+"Health mode" (also known as "Cold plasma") enables the ionizer air purification feature on supported HVACs.
+
 ## Links
 [Gree app in Homey Apps](https://apps.athom.com/app/com.gree)
 

--- a/README.nl.txt
+++ b/README.nl.txt
@@ -33,3 +33,6 @@ Opmerkingen
 
 * Verticale zwaai
 ** "Uitgeschakeld"/"Standaard" positie betekent dat de verticale zwaai wordt gestopt en op de huidige positie blijft staan.
+
+* Gezondheidsmodus
+** "Gezondheidsmodus" (ook bekend als "Koud plasma") schakelt de ionisator-luchtreinigingsfunctie in op ondersteunde HVAC's.

--- a/README.txt
+++ b/README.txt
@@ -32,3 +32,6 @@ Notes
 
 * Vertical swing
 ** "Disabled"/"Default" position means that vertical swing will be stopped and left on the current position.
+
+* Health mode
+** "Health mode" (also known as "Cold plasma") enables the ionizer air purification feature on supported HVACs.

--- a/app.js
+++ b/app.js
@@ -80,6 +80,13 @@ class GreeHVAC extends Homey.App {
                 return args.mode === quietMode;
             });
 
+        this.homey.flow.getConditionCard('health_mode_is')
+            .registerRunListener((args, state) => {
+                const healthMode = args.device.getCapabilityValue('health_mode');
+                args.device.log('[condition]', '[current health mode]', healthMode);
+                return onoffToBoolean(args.mode) === healthMode;
+            });
+
         // Register actions for flows
         this.homey.flow.getActionCard('set_hvac_mode')
             .registerRunListener((args, state) => {
@@ -149,6 +156,14 @@ class GreeHVAC extends Homey.App {
                 return args.device.setCapabilityValue('quiet_mode', args.mode)
                     .then(() => {
                         return args.device.triggerCapabilityListener('quiet_mode', args.mode, {});
+                    });
+            });
+
+        this.homey.flow.getActionCard('set_health_mode')
+            .registerRunListener((args, state) => {
+                return args.device.setCapabilityValue('health_mode', onoffToBoolean(args.mode))
+                    .then(() => {
+                        return args.device.triggerCapabilityListener('health_mode', onoffToBoolean(args.mode), {});
                     });
             });
     }

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.gree",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "compatibility": ">=12.0.1",
   "sdk": 3,
   "brandColor": "#ff732e",
@@ -307,6 +307,33 @@
               "de": "Ruhig-Modus"
             },
             "example": "off"
+          }
+        ]
+      },
+      {
+        "id": "health_mode_changed",
+        "title": {
+          "en": "Health mode changed",
+          "nl": "Gezondheidsmodus veranderd",
+          "de": "Gesundheitsmodus geändert"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=gree_cooper_hunter_hvac"
+          }
+        ],
+        "tokens": [
+          {
+            "name": "health_mode",
+            "type": "boolean",
+            "title": {
+              "en": "Health mode",
+              "nl": "Gezondheidsmodus",
+              "de": "Gesundheitsmodus"
+            },
+            "example": "true"
           }
         ]
       }
@@ -841,6 +868,44 @@
                   "en": "Mode 3",
                   "nl": "Mode 3",
                   "de": "Mode 3"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "health_mode_is",
+        "title": {
+          "en": "Health mode !{{is|isn't}} ..."
+        },
+        "titleFormatted": {
+          "en": "Health mode !{{is|isn't}} [[mode]]"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=gree_cooper_hunter_hvac"
+          },
+          {
+            "name": "mode",
+            "type": "dropdown",
+            "values": [
+              {
+                "id": "on",
+                "label": {
+                  "en": "On",
+                  "nl": "Aan",
+                  "de": "Einschalten"
+                }
+              },
+              {
+                "id": "off",
+                "label": {
+                  "en": "Off",
+                  "nl": "Uit",
+                  "de": "Ausschalten"
                 }
               }
             ]
@@ -1419,6 +1484,48 @@
             ]
           }
         ]
+      },
+      {
+        "id": "set_health_mode",
+        "title": {
+          "en": "Set health mode",
+          "nl": "Stel de gezondheidsmodus in",
+          "de": "Stellen Sie den Gesundheitsmodus ein"
+        },
+        "titleFormatted": {
+          "en": "Set health mode to [[mode]]",
+          "nl": "Stel de gezondheidsmodus in op [[mode]]",
+          "de": "Stellen Sie den Gesundheitsmodus auf [[mode]] ein"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=gree_cooper_hunter_hvac"
+          },
+          {
+            "name": "mode",
+            "type": "dropdown",
+            "values": [
+              {
+                "id": "on",
+                "label": {
+                  "en": "On",
+                  "nl": "Aan",
+                  "de": "Einschalten"
+                }
+              },
+              {
+                "id": "off",
+                "label": {
+                  "en": "Off",
+                  "nl": "Uit",
+                  "de": "Ausschalten"
+                }
+              }
+            ]
+          }
+        ]
       }
     ]
   },
@@ -1440,7 +1547,8 @@
         "xfan_mode",
         "vertical_swing",
         "horizontal_swing",
-        "quiet_mode"
+        "quiet_mode",
+        "health_mode"
       ],
       "capabilitiesOptions": {
         "target_temperature": {
@@ -1620,6 +1728,22 @@
       "getable": true,
       "setable": true,
       "uiComponent": "picker"
+    },
+    "health_mode": {
+      "type": "boolean",
+      "title": {
+        "en": "Health mode",
+        "nl": "Gezondheidsmodus",
+        "de": "Gesundheitsmodus"
+      },
+      "desc": {
+        "en": "Cold plasma / ionizer air purification mode of the HVAC",
+        "nl": "Koud plasma / ionisator luchtreinigingsmodus van de HVAC",
+        "de": "Kaltplasma- / Ionisator-Luftreinigungsmodus der Klimaanlage"
+      },
+      "getable": true,
+      "setable": true,
+      "uiComponent": "toggle"
     },
     "horizontal_swing": {
       "type": "enum",

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -67,6 +67,7 @@ class GreeHVACDevice extends Homey.Device {
         this._flowTriggerVerticalSwingChanged = this.homey.flow.getDeviceTriggerCard('vertical_swing_changed');
         this._flowTriggerHorizontalSwingChanged = this.homey.flow.getDeviceTriggerCard('horizontal_swing_changed');
         this._flowTriggerQuietModeChanged = this.homey.flow.getDeviceTriggerCard('quiet_mode_changed');
+        this._flowTriggerHealthModeChanged = this.homey.flow.getDeviceTriggerCard('health_mode_changed');
 
         await this._executeCapabilityMigrations();
         await this._executeDeviceClassMigration();
@@ -355,6 +356,15 @@ class GreeHVACDevice extends Homey.Device {
 
             return Promise.resolve();
         });
+
+        this.registerCapabilityListener('health_mode', (value) => {
+            const rawValue = value ? HVAC.VALUE.health.on : HVAC.VALUE.health.off;
+            this.log('[health mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
+            this._setClientProperty(HVAC.PROPERTY.health, rawValue);
+            this._flowTriggerHealthModeChanged.trigger(this, { health_mode: value });
+
+            return Promise.resolve();
+        });
     }
 
     /**
@@ -536,6 +546,14 @@ class GreeHVACDevice extends Homey.Device {
             this.setCapabilityValue('quiet_mode', value).then(() => {
                 this.log('[update properties]', '[quiet_mode]', value);
                 return this._flowTriggerQuietModeChanged.trigger(this, { quiet_mode: value });
+            }).catch(this.error);
+        }
+
+        if (this._checkBoolPropertyChanged(updatedProperties, HVAC.PROPERTY.health, 'health_mode')) {
+            const value = updatedProperties[HVAC.PROPERTY.health] === HVAC.VALUE.health.on;
+            this.setCapabilityValue('health_mode', value).then(() => {
+                this.log('[update properties]', '[health_mode]', value);
+                return this._flowTriggerHealthModeChanged.trigger(this, { health_mode: value });
             }).catch(this.error);
         }
     }
@@ -809,6 +827,12 @@ class GreeHVACDevice extends Homey.Device {
         if (!this.hasCapability('safety_heating')) {
             this.log('[migration v0.9.4]', 'Adding "safety_heating" capability');
             await this.addCapability('safety_heating');
+        }
+
+        // Added in v0.13.0
+        if (!this.hasCapability('health_mode')) {
+            this.log('[migration v0.13.0]', 'Adding "health_mode" capability');
+            await this.addCapability('health_mode');
         }
     }
 

--- a/drivers/gree_cooper_hunter_hvac/driver.compose.json
+++ b/drivers/gree_cooper_hunter_hvac/driver.compose.json
@@ -15,7 +15,8 @@
     "xfan_mode",
     "vertical_swing",
     "horizontal_swing",
-    "quiet_mode"
+    "quiet_mode",
+    "health_mode"
   ],
   "capabilitiesOptions": {
     "target_temperature": {

--- a/drivers/gree_cooper_hunter_hvac/driver.flow.compose.json
+++ b/drivers/gree_cooper_hunter_hvac/driver.flow.compose.json
@@ -173,6 +173,27 @@
           "example": "off"
         }
       ]
+    },
+    {
+      "id": "health_mode_changed",
+      "title": {
+        "en": "Health mode changed",
+        "nl": "Gezondheidsmodus veranderd",
+        "de": "Gesundheitsmodus geändert"
+      },
+      "args": [],
+      "tokens": [
+        {
+          "name": "health_mode",
+          "type": "boolean",
+          "title": {
+            "en": "Health mode",
+            "nl": "Gezondheidsmodus",
+            "de": "Gesundheitsmodus"
+          },
+          "example": "true"
+        }
+      ]
     }
   ],
   "conditions": [
@@ -660,6 +681,39 @@
                 "en": "Mode 3",
                 "nl": "Mode 3",
                 "de": "Mode 3"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "health_mode_is",
+      "title": {
+        "en": "Health mode !{{is|isn't}} ..."
+      },
+      "titleFormatted": {
+        "en": "Health mode !{{is|isn't}} [[mode]]"
+      },
+      "args": [
+        {
+          "name": "mode",
+          "type": "dropdown",
+          "values": [
+            {
+              "id": "on",
+              "label": {
+                "en": "On",
+                "nl": "Aan",
+                "de": "Einschalten"
+              }
+            },
+            {
+              "id": "off",
+              "label": {
+                "en": "Off",
+                "nl": "Uit",
+                "de": "Ausschalten"
               }
             }
           ]
@@ -1188,6 +1242,43 @@
                 "en": "Mode 3",
                 "nl": "Mode 3",
                 "de": "Mode 3"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "set_health_mode",
+      "title": {
+        "en": "Set health mode",
+        "nl": "Stel de gezondheidsmodus in",
+        "de": "Stellen Sie den Gesundheitsmodus ein"
+      },
+      "titleFormatted": {
+        "en": "Set health mode to [[mode]]",
+        "nl": "Stel de gezondheidsmodus in op [[mode]]",
+        "de": "Stellen Sie den Gesundheitsmodus auf [[mode]] ein"
+      },
+      "args": [
+        {
+          "name": "mode",
+          "type": "dropdown",
+          "values": [
+            {
+              "id": "on",
+              "label": {
+                "en": "On",
+                "nl": "Aan",
+                "de": "Einschalten"
+              }
+            },
+            {
+              "id": "off",
+              "label": {
+                "en": "Off",
+                "nl": "Uit",
+                "de": "Ausschalten"
               }
             }
           ]

--- a/test/device.healthMode.test.js
+++ b/test/device.healthMode.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+describe('GreeHVACDevice health_mode listener', () => {
+    let GreeHVACDevice;
+    let device;
+    let capabilityListeners;
+
+    beforeEach(() => {
+        jest.resetModules();
+
+        capabilityListeners = {};
+
+        jest.doMock('../drivers/gree_cooper_hunter_hvac/network/finder', () => ({ hvacs: [] }));
+
+        jest.doMock('gree-hvac-client', () => ({
+            PROPERTY: { health: 'health' },
+            VALUE: {
+                health: {
+                    off: 'off',
+                    on: 'on',
+                },
+            },
+        }));
+
+        jest.doMock('homey', () => ({
+            Device: class Device {
+                log() {}
+                error() {}
+            },
+        }));
+
+        GreeHVACDevice = require('../drivers/gree_cooper_hunter_hvac/device');
+
+        device = new GreeHVACDevice();
+        device.registerCapabilityListener = jest.fn((capability, listener) => {
+            capabilityListeners[capability] = listener;
+        });
+        device._setClientProperty = jest.fn();
+        device._flowTriggerHealthModeChanged = {
+            trigger: jest.fn(),
+        };
+        device.log = jest.fn();
+    });
+
+    test('turns health mode on', async () => {
+        device._registerCapabilityListeners();
+
+        await capabilityListeners.health_mode(true);
+
+        expect(device._setClientProperty).toHaveBeenCalledWith('health', 'on');
+        expect(device._flowTriggerHealthModeChanged.trigger).toHaveBeenCalledWith(device, { health_mode: true });
+    });
+
+    test('turns health mode off', async () => {
+        device._registerCapabilityListeners();
+
+        await capabilityListeners.health_mode(false);
+
+        expect(device._setClientProperty).toHaveBeenCalledWith('health', 'off');
+        expect(device._flowTriggerHealthModeChanged.trigger).toHaveBeenCalledWith(device, { health_mode: false });
+    });
+});


### PR DESCRIPTION
Closes #5

Adds support for enabling the HVAC's **Health** mode (cold plasma / ionizer air purification), which has on/off values. Implemented by mirroring the existing `safety_heating` / `xfan_mode` boolean-toggle pattern end-to-end.

## Changes

- **New capability** `health_mode` (boolean toggle, en/nl/de)
- **Flow cards**: `health_mode_changed` trigger, `health_mode_is` condition, `set_health_mode` action (with `titleFormatted`)
- **Device** (`device.js`): registered trigger card, capability listener mapping to `HVAC.PROPERTY.health`, `_onUpdate` sync, and a v0.13.0 migration to add the capability to already-paired devices
- **App** (`app.js`): registered the condition and action run-listeners
- **Versioning**: bumped to `0.13.0` with a changelog entry
- **Docs**: documented the new mode in the README files
- **Tests**: `test/device.healthMode.test.js` covering on/off listener behavior

## Verification

- Rebased on master; `npm test` (eslint + jest): all 77 tests pass
- `homey app validate -l publish`: passes with no warnings
- `app.json` regenerated via `homey app build` and kept in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)