### PR TITLE
Support AES-GCM devices (firmware V2.x)

### DIFF
--- a/drivers/gree_cooper_hunter_hvac/network/finder.js
+++ b/drivers/gree_cooper_hunter_hvac/network/finder.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const dgram = require('dgram');
-const { EncryptionService } = require('gree-hvac-client/src/encryption-service');
+const { EcbCipher, GcmCipher } = require('gree-hvac-client/src/encryption-service');
 const { createLogger } = require('gree-hvac-client/src/logger');
 const { randomUUID } = require('crypto');
 
@@ -15,7 +15,9 @@ class Finder {
             service: 'finder',
             sid: randomUUID(),
         });
-        this._encryptionService = new EncryptionService(this._encryptionServiceLogger);
+        // Devices answer the scan with their generic key. Older devices use
+        // AES-ECB, newer ones (firmware V2.x) use AES-GCM, so try both.
+        this._ciphers = [new EcbCipher(), new GcmCipher()];
         this._hvacs = {};
         this.start();
     }
@@ -57,7 +59,7 @@ class Finder {
                 return;
             }
 
-            const decryptedMessage = this._encryptionService.decrypt(parsedMessage);
+            const decryptedMessage = this._decrypt(parsedMessage);
 
             this._hvacs[decryptedMessage.mac] = { message: decryptedMessage, remoteInfo };
 
@@ -93,6 +95,25 @@ class Finder {
                 message,
             });
         }
+    }
+
+    /**
+     * Decrypt a device message, trying each supported cipher (ECB / GCM).
+     *
+     * @param {object} message Parsed UDP message with a `pack` field
+     * @returns {object} Decrypted payload
+     * @private
+     */
+    _decrypt(message) {
+        let lastError;
+        for (const cipher of this._ciphers) {
+            try {
+                return cipher.decrypt(message).payload;
+            } catch (error) {
+                lastError = error;
+            }
+        }
+        throw lastError;
     }
 
     _restart(reason) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "eslint": "^7.32.0",
         "eslint-config-athom": "^3.1.5",
         "homey": "^4.3.0",
-        "jest": "^30.4.2"
+        "jest": "^30.4.2",
+        "patch-package": "^8.0.1"
       },
       "engines": {
         "node": ">=16"
@@ -2856,6 +2857,13 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -5895,6 +5903,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -8650,6 +8668,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -8683,6 +8721,16 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8691,6 +8739,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kuler": {
@@ -9713,6 +9771,89 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/path-exists": {
@@ -12329,6 +12470,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test": "npm run eslint && jest",
     "eslint": "eslint .",
-    "jest": "jest"
+    "jest": "jest",
+    "postinstall": "patch-package"
   },
   "jest": {
     "testEnvironment": "node",
@@ -32,7 +33,8 @@
     "eslint": "^7.32.0",
     "eslint-config-athom": "^3.1.5",
     "homey": "^4.3.0",
-    "jest": "^30.4.2"
+    "jest": "^30.4.2",
+    "patch-package": "^8.0.1"
   },
   "engines": {
     "node": ">=16"

--- a/patches/gree-hvac-client+3.0.3.patch
+++ b/patches/gree-hvac-client+3.0.3.patch
@@ -1,0 +1,59 @@
+diff --git a/node_modules/gree-hvac-client/src/encryption-service.js b/node_modules/gree-hvac-client/src/encryption-service.js
+index 5b4314f..ec509d2 100644
+--- a/node_modules/gree-hvac-client/src/encryption-service.js
++++ b/node_modules/gree-hvac-client/src/encryption-service.js
+@@ -61,7 +61,7 @@ class EncryptionService {
+      * @returns {object}
+      */
+     decrypt(input) {
+-        const decrypted = this._activeCipher.decrypt(input);
++        const decrypted = this._decryptWithFallback(input);
+         const payload = decrypted.payload;
+ 
+         if (payload.t === 'bindok') {
+@@ -73,6 +73,45 @@ class EncryptionService {
+         return payload;
+     }
+ 
++    /**
++     * Decrypt using the active cipher, falling back to the other cipher.
++     *
++     * Newer devices (firmware V2.x) answer the scan/handshake with a GCM
++     * encrypted message before any bind has happened, so we cannot rely on the
++     * bind-attempt counter to pick the cipher. Auto-detect instead: try the
++     * active cipher first, then the other one, and make whichever succeeds the
++     * active cipher. GCM is authenticated and ECB validates via JSON parsing,
++     * so a wrong cipher reliably throws rather than returning garbage.
++     *
++     * @param {object} input Response object
++     * @returns {object}
++     * @private
++     */
++    _decryptWithFallback(input) {
++        const ciphers =
++            this._activeCipher === this._gcmCipher
++                ? [this._gcmCipher, this._aesCipher]
++                : [this._aesCipher, this._gcmCipher];
++
++        let lastError;
++        for (const cipher of ciphers) {
++            try {
++                const decrypted = cipher.decrypt(input);
++                if (this._activeCipher !== cipher) {
++                    this._logger.debug('Switching active cipher', {
++                        cipher: decrypted.cipher,
++                    });
++                    this._activeCipher = cipher;
++                }
++                return decrypted;
++            } catch (error) {
++                lastError = error;
++            }
++        }
++
++        throw lastError;
++    }
++
+     /**
+      * Encrypt UDP message
+      *

--- a/test/encryption.gcm.test.js
+++ b/test/encryption.gcm.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const {
+    EncryptionService,
+    GcmCipher,
+} = require('gree-hvac-client/src/encryption-service');
+const { createLogger } = require('gree-hvac-client/src/logger');
+
+// A real scan ("dev") response captured from a Gree device running firmware
+// V2.0.0, which encrypts with AES-128-GCM (note the `tag` field). Older
+// firmware uses AES-128-ECB and has no tag.
+const GCM_DEV_MESSAGE = {
+    t: 'pack',
+    i: 1,
+    uid: 0,
+    cid: '502cc66cd76a',
+    tcid: '51d96e700597',
+    tag: 'C5OIbVRLeXT6G7K6h+ZUTA==',
+    pack:
+        'JtoKliwtrZWlpNCVOSARFZVjvdMQgUTwNgcwCuyKhOTTdG5N10M5OI3w9aCGCJ'
+        + 'ffjfuyCITofrMT4JbII6+A1+2Qyk7gfwk5dZR2EayhdZgEoOSGGofp1NG95s5quv'
+        + '8eFq+2oChWDqTDGSfh0Qvsoz/uHnpJj7cgLseHEa1Qy49usnE8T0XpY+Ox/g0sCK'
+        + '2y2vzlARuL1vKmpT7wkMRwPTuo1zE7mhrFvdLWdzI6Z6osCeD6tdJoLaE7k6FHvg'
+        + 'hQKe+boL4=',
+};
+
+const logger = createLogger('error').child({ service: 'test' });
+
+describe('GCM encryption support (patched gree-hvac-client)', () => {
+    test('GcmCipher decrypts a V2.x device scan response', () => {
+        const { payload } = new GcmCipher().decrypt(GCM_DEV_MESSAGE);
+
+        expect(payload.t).toBe('dev');
+        expect(payload.mac).toBe('502cc66cd76a');
+        expect(payload.ver).toBe('V2.0.0');
+    });
+
+    test('EncryptionService auto-detects GCM even though it defaults to ECB', () => {
+        // Regression guard for patches/gree-hvac-client+3.0.3.patch: the service
+        // must fall back from the default ECB cipher to GCM, otherwise GCM
+        // devices fail to decrypt with ERR_OSSL_WRONG_FINAL_BLOCK_LENGTH and are
+        // never discovered.
+        const service = new EncryptionService(logger);
+
+        const payload = service.decrypt(GCM_DEV_MESSAGE);
+
+        expect(payload.t).toBe('dev');
+        expect(payload.mac).toBe('502cc66cd76a');
+    });
+});

--- a/test/finder.probe.test.js
+++ b/test/finder.probe.test.js
@@ -25,16 +25,20 @@ describe('Finder.probe()', () => {
             createSocket: jest.fn(() => fakeSocket),
         }));
 
-        jest.doMock('gree-hvac-client/src/encryption-service', () => ({
-            EncryptionService: jest.fn().mockImplementation(() => ({
-                decrypt: jest.fn((msg) => ({
+        jest.doMock('gree-hvac-client/src/encryption-service', () => {
+            const decrypt = jest.fn(() => ({
+                payload: {
                     mac: 'aabbccddeeff',
                     cid: 'aabbccddeeff',
                     name: 'TestDevice',
                     t: 'dev',
-                })),
-            })),
-        }));
+                },
+            }));
+            return {
+                EcbCipher: jest.fn().mockImplementation(() => ({ decrypt })),
+                GcmCipher: jest.fn().mockImplementation(() => ({ decrypt })),
+            };
+        });
 
         jest.doMock('gree-hvac-client/src/logger', () => ({
             createLogger: jest.fn(() => ({


### PR DESCRIPTION
## Problem

Newer Gree / Cooper&Hunter units (e.g. firmware `V2.0.0`) encrypt UDP traffic with **AES-128-GCM** instead of legacy **AES-128-ECB**. Such devices:

- are **never discovered** ("airco not found", even via static IP), and
- **cannot bind** if already paired — they go offline in a reconnect loop.

The tell-tale symptom in logs is `ERR_OSSL_WRONG_FINAL_BLOCK_LENGTH` / `Can not decrypt message (...wrong final block length)`, plus a `tag` field on every packet (the GCM auth tag — ECB packets have none).

Root cause: both the discovery `Finder` and the `gree-hvac-client` connection logic only ever attempted ECB. The library *has* GCM support but only switches on the **2nd bind attempt** — and binding is gated behind a successful handshake whose `dev` response is itself GCM, so it never gets there.

A real captured scan response decrypts cleanly under GCM only:
```json
{"t":"dev","cid":"502cc66cd76a","mac":"502cc66cd76a","model":"gree","ver":"V2.0.0","lock":0}
```

## Changes

- **`patches/gree-hvac-client+3.0.3.patch`** — `EncryptionService.decrypt` now tries the active cipher and falls back to the other, making whichever succeeds the active cipher. This auto-detects GCM from the first scan/handshake response, fixing the chicken-and-egg bind flaw. Safe both ways: GCM is authenticated and ECB validates via JSON parsing, so the wrong cipher reliably throws.
- **`network/finder.js`** — tries both `EcbCipher` and `GcmCipher` for scan responses (broadcast discovery + static-IP `probe()`).
- **Tooling** — added `patch-package` (devDependency) + `postinstall` so the lib fix re-applies on every install/build (`node_modules` is gitignored, `patches/` is tracked).
- **Tests** — new `test/encryption.gcm.test.js` decrypts a real `V2.0.0` GCM packet as a regression guard; updated finder mock.

ECB (older) devices are unaffected — they decode on the first cipher tried.

## Testing

`npm test` — eslint clean, 33/33 tests pass.

## Follow-up

The fix is applied via `patch-package` against a vendored GitHub dependency. Worth upstreaming to `apachler/gree-hvac-client` so the patch can eventually be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)