### PR TITLE
Fix crash, reconnect, flow-trigger and UDP robustness bugs found in code review

### DIFF
--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -130,6 +130,14 @@ class GreeHVACDevice extends Homey.Device {
 
         const mac = this.getMac();
 
+        if (!mac) {
+            // Paired via "Skip UDP scan" and never connected so far:
+            // the real MAC is unknown until the first successful
+            // connection via static IP, so discovery cannot match anything
+            this.log('[find devices]', 'MAC is not known yet. Set a static IP to connect');
+            return;
+        }
+
         this.log('[find devices]', 'Finding device with mac:', mac);
 
         finder.hvacs.forEach((hvac) => {
@@ -781,11 +789,12 @@ class GreeHVACDevice extends Homey.Device {
     /**
      * Get the MAC address of the HVAC.
      *
-     * Devices paired via "Skip UDP scan" have the IP address stored as MAC
-     * in the immutable device data. For them the real MAC (resolved on the
-     * first successful connection) is kept in the device store.
+     * Devices paired via "Skip UDP scan" have no MAC in the immutable device
+     * data (older versions stored the IP address there instead). For them the
+     * real MAC, resolved on the first successful connection, is kept in the
+     * device store.
      *
-     * @returns {string}
+     * @returns {string|undefined}
      */
     getMac() {
         return this.getStoreValue('mac') || this.getData().mac;

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -128,12 +128,12 @@ class GreeHVACDevice extends Homey.Device {
             return;
         }
 
-        const deviceData = this.getData();
+        const mac = this.getMac();
 
-        this.log('[find devices]', 'Finding device with mac:', deviceData.mac);
+        this.log('[find devices]', 'Finding device with mac:', mac);
 
         finder.hvacs.forEach((hvac) => {
-            if (hvac.message.mac !== deviceData.mac) {
+            if (hvac.message.mac !== mac) {
                 // Skip other HVACs from the finder until find current
                 this.log('[find devices]', 'Skipping HVAC with mac:', hvac.message.mac);
                 return;
@@ -328,6 +328,7 @@ class GreeHVACDevice extends Homey.Device {
         this.log('[connect]', 'connected to', client.getDeviceId());
         this.log('[connect]', 'mark device available');
         this._cancelNoResponseReconnect();
+        this._updateMacFromClient(client);
         this.setAvailable();
     }
 
@@ -775,6 +776,40 @@ class GreeHVACDevice extends Homey.Device {
         if (this.getClass() !== 'airconditioning') {
             await this.setClass('airconditioning').catch(this.error);
         }
+    }
+
+    /**
+     * Get the MAC address of the HVAC.
+     *
+     * Devices paired via "Skip UDP scan" have the IP address stored as MAC
+     * in the immutable device data. For them the real MAC (resolved on the
+     * first successful connection) is kept in the device store.
+     *
+     * @returns {string}
+     */
+    getMac() {
+        return this.getStoreValue('mac') || this.getData().mac;
+    }
+
+    /**
+     * Persist the real MAC reported by the connected HVAC when it differs
+     * from what is currently known (i.e. the device was paired via
+     * "Skip UDP scan" with the IP address as a placeholder MAC).
+     * This makes MAC-based discovery work for such devices,
+     * e.g. after the static IP setting is cleared.
+     *
+     * @param {HVAC.Client} client
+     * @private
+     */
+    _updateMacFromClient(client) {
+        const mac = client.getDeviceId();
+
+        if (!mac || mac === this.getMac()) {
+            return;
+        }
+
+        this.log('[connect]', 'Updating stored mac to:', mac);
+        this.setStoreValue('mac', mac).catch(this.error);
     }
 
     /**

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -662,7 +662,9 @@ class GreeHVACDevice extends Homey.Device {
     _tryToDisconnect() {
         if (this._client) {
             this._client.removeAllListeners();
-            this._client.disconnect();
+            // disconnect() rejects when the client has no active socket
+            // (e.g. in the middle of its own reconnect cycle)
+            this._client.disconnect().catch(this.error);
             this._client = null;
         }
     }

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -3,7 +3,7 @@
 const Homey = require('homey');
 const HVAC = require('gree-hvac-client');
 const finder = require('./network/finder');
-const { compareBoolProperties } = require('../../utils');
+const { compareBoolProperties, isValidIpv4 } = require('../../utils');
 
 // Interval between trying to found HVAC in network (ms)
 const LOOKING_FOR_DEVICE_TIME_INTERVAL = 5000;
@@ -96,6 +96,10 @@ class GreeHVACDevice extends Homey.Device {
 
         if (oldSettings.static_ip === newSettings.static_ip) {
             return;
+        }
+
+        if (newSettings.static_ip && !isValidIpv4(newSettings.static_ip)) {
+            throw new Error(this.homey.__('error.invalid_static_ip'));
         }
 
         this.log('[settings]', 'Static IP changed. Reconnecting.');
@@ -677,11 +681,12 @@ class GreeHVACDevice extends Homey.Device {
      * @private
      */
     _getStaticIpSetting() {
-        if (this._staticIpSetting !== undefined) {
-            return this._staticIpSetting;
-        }
+        const value = this._staticIpSetting !== undefined
+            ? this._staticIpSetting
+            : this.getSetting('static_ip');
 
-        return this.getSetting('static_ip');
+        // The user may have entered the IP with surrounding whitespace
+        return typeof value === 'string' ? value.trim() : value;
     }
 
     /**

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -801,19 +801,29 @@ class GreeHVACDevice extends Homey.Device {
     }
 
     /**
-     * Persist the real MAC reported by the connected HVAC when it differs
-     * from what is currently known (i.e. the device was paired via
-     * "Skip UDP scan" with the IP address as a placeholder MAC).
-     * This makes MAC-based discovery work for such devices,
+     * Persist the real MAC reported by the connected HVAC for devices
+     * paired via "Skip UDP scan": they have either no MAC at all or,
+     * for devices paired by older app versions, the IP address as a
+     * placeholder MAC. This makes MAC-based discovery work for them,
      * e.g. after the static IP setting is cleared.
+     *
+     * A real MAC obtained during pairing is never overwritten: discovery
+     * matches on the MAC broadcast by the device, while getDeviceId()
+     * returns the client cid, which is not guaranteed to be identical.
      *
      * @param {HVAC.Client} client
      * @private
      */
     _updateMacFromClient(client) {
+        const knownMac = this.getMac();
+
+        if (knownMac && !isValidIpv4(knownMac)) {
+            return;
+        }
+
         const mac = client.getDeviceId();
 
-        if (!mac || mac === this.getMac()) {
+        if (!mac || mac === knownMac) {
             return;
         }
 

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -173,14 +173,14 @@ class GreeHVACDevice extends Homey.Device {
 
             if (rawValue === HVAC.VALUE.power.off) {
                 // Set Thermostat mode to Off.
-                this.setCapabilityValue('thermostat_mode', 'off');
+                this.setCapabilityValue('thermostat_mode', 'off').catch(this.error);
             } else {
                 // Restore thermostat_mode.
-                const properties = this._client._transformer.fromVendor(this._client._properties);
+                const properties = this._getCurrentClientProperties();
                 const mode = properties[HVAC.PROPERTY.mode];
 
                 if (mode !== undefined) {
-                    this.setCapabilityValue('thermostat_mode', HVAC.VALUE.mode[mode]);
+                    this.setCapabilityValue('thermostat_mode', HVAC.VALUE.mode[mode]).catch(this.error);
                 }
             }
 
@@ -198,16 +198,16 @@ class GreeHVACDevice extends Homey.Device {
             if (value === 'off') {
                 this.log('[power mode change]', `Value: ${value}`);
                 this._setClientProperty(HVAC.PROPERTY.power, HVAC.VALUE.power.off);
-                this.setCapabilityValue('onoff', false);
+                this.setCapabilityValue('onoff', false).catch(this.error);
             } else {
                 const rawValue = HVAC.VALUE.mode[value];
                 this.log('[thermostat_mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
                 this._setClientProperty(HVAC.PROPERTY.mode, rawValue);
 
                 // Turn on if needed.
-                const properties = this._client._transformer.fromVendor(this._client._properties);
+                const properties = this._getCurrentClientProperties();
                 if (properties[HVAC.PROPERTY.power] === HVAC.VALUE.power.off) {
-                    this.setCapabilityValue('onoff', true);
+                    this.setCapabilityValue('onoff', true).catch(this.error);
                     this._setClientProperty(HVAC.PROPERTY.power, HVAC.VALUE.power.on);
                 }
             }
@@ -712,6 +712,22 @@ class GreeHVACDevice extends Homey.Device {
         if (this.getClass() !== 'airconditioning') {
             await this.setClass('airconditioning').catch(this.error);
         }
+    }
+
+    /**
+     * Get the latest known HVAC properties in the API format.
+     * Returns an empty object when the client is not connected,
+     * e.g. while the device is still being discovered or is reconnecting.
+     *
+     * @returns {Object}
+     * @private
+     */
+    _getCurrentClientProperties() {
+        if (!this._client) {
+            return {};
+        }
+
+        return this._client._transformer.fromVendor(this._client._properties);
     }
 
     /**

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -231,8 +231,9 @@ class GreeHVACDevice extends Homey.Device {
         this.registerCapabilityListener('fan_speed', (value) => {
             const rawValue = HVAC.VALUE.fanSpeed[value];
             this.log('[fan speed change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            this._setClientProperty(HVAC.PROPERTY.fanSpeed, rawValue);
-            this._flowTriggerHvacFanSpeedChanged.trigger(this, { fan_speed: value });
+            if (this._setClientProperty(HVAC.PROPERTY.fanSpeed, rawValue)) {
+                this._flowTriggerHvacFanSpeedChanged.trigger(this, { fan_speed: value });
+            }
 
             return Promise.resolve();
         });
@@ -240,8 +241,9 @@ class GreeHVACDevice extends Homey.Device {
         this.registerCapabilityListener('turbo_mode', (value) => {
             const rawValue = value ? HVAC.VALUE.turbo.on : HVAC.VALUE.turbo.off;
             this.log('[turbo mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            this._setClientProperty(HVAC.PROPERTY.turbo, rawValue);
-            this._flowTriggerTurboModeChanged.trigger(this, { turbo_mode: value });
+            if (this._setClientProperty(HVAC.PROPERTY.turbo, rawValue)) {
+                this._flowTriggerTurboModeChanged.trigger(this, { turbo_mode: value });
+            }
 
             return Promise.resolve();
         });
@@ -249,8 +251,9 @@ class GreeHVACDevice extends Homey.Device {
         this.registerCapabilityListener('safety_heating', (value) => {
             const rawValue = value ? HVAC.VALUE.safetyHeating.on : HVAC.VALUE.safetyHeating.off;
             this.log('[safety heating change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            this._setClientProperty(HVAC.PROPERTY.safetyHeating, rawValue);
-            this._flowTriggerSafetyHeatingChanged.trigger(this, { safety_heating: value });
+            if (this._setClientProperty(HVAC.PROPERTY.safetyHeating, rawValue)) {
+                this._flowTriggerSafetyHeatingChanged.trigger(this, { safety_heating: value });
+            }
 
             return Promise.resolve();
         });
@@ -258,8 +261,9 @@ class GreeHVACDevice extends Homey.Device {
         this.registerCapabilityListener('lights', (value) => {
             const rawValue = value ? HVAC.VALUE.lights.on : HVAC.VALUE.lights.off;
             this.log('[lights change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            this._setClientProperty(HVAC.PROPERTY.lights, rawValue);
-            this._flowTriggerHvacLightsChanged.trigger(this, { lights: value });
+            if (this._setClientProperty(HVAC.PROPERTY.lights, rawValue)) {
+                this._flowTriggerHvacLightsChanged.trigger(this, { lights: value });
+            }
 
             return Promise.resolve();
         });
@@ -267,8 +271,9 @@ class GreeHVACDevice extends Homey.Device {
         this.registerCapabilityListener('xfan_mode', (value) => {
             const rawValue = value ? HVAC.VALUE.blow.on : HVAC.VALUE.blow.off;
             this.log('[xfan mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            this._setClientProperty(HVAC.PROPERTY.blow, rawValue);
-            this._flowTriggerXFanModeChanged.trigger(this, { xfan_mode: value });
+            if (this._setClientProperty(HVAC.PROPERTY.blow, rawValue)) {
+                this._flowTriggerXFanModeChanged.trigger(this, { xfan_mode: value });
+            }
 
             return Promise.resolve();
         });
@@ -276,8 +281,9 @@ class GreeHVACDevice extends Homey.Device {
         this.registerCapabilityListener('vertical_swing', (value) => {
             const rawValue = HVAC.VALUE.swingVert[value];
             this.log('[vertical swing change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            this._setClientProperty(HVAC.PROPERTY.swingVert, rawValue);
-            this._flowTriggerVerticalSwingChanged.trigger(this, { vertical_swing: value });
+            if (this._setClientProperty(HVAC.PROPERTY.swingVert, rawValue)) {
+                this._flowTriggerVerticalSwingChanged.trigger(this, { vertical_swing: value });
+            }
 
             return Promise.resolve();
         });
@@ -285,8 +291,9 @@ class GreeHVACDevice extends Homey.Device {
         this.registerCapabilityListener('horizontal_swing', (value) => {
             const rawValue = HVAC.VALUE.swingHor[value];
             this.log('[horizontal swing change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            this._setClientProperty(HVAC.PROPERTY.swingHor, rawValue);
-            this._flowTriggerHorizontalSwingChanged.trigger(this, { horizontal_swing: value });
+            if (this._setClientProperty(HVAC.PROPERTY.swingHor, rawValue)) {
+                this._flowTriggerHorizontalSwingChanged.trigger(this, { horizontal_swing: value });
+            }
 
             return Promise.resolve();
         });
@@ -298,8 +305,9 @@ class GreeHVACDevice extends Homey.Device {
             }
             const rawValue = HVAC.VALUE.quiet[value];
             this.log('[quiet mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            this._setClientProperty(HVAC.PROPERTY.quiet, rawValue);
-            this._flowTriggerQuietModeChanged.trigger(this, { quiet_mode: value });
+            if (this._setClientProperty(HVAC.PROPERTY.quiet, rawValue)) {
+                this._flowTriggerQuietModeChanged.trigger(this, { quiet_mode: value });
+            }
 
             return Promise.resolve();
         });
@@ -783,12 +791,17 @@ class GreeHVACDevice extends Homey.Device {
      *
      * @param property
      * @param value
+     * @returns {boolean} true when the command was sent to the HVAC
      * @private
      */
     _setClientProperty(property, value) {
-        if (this._client) {
-            this._client.setProperty(property, value);
+        if (!this._client) {
+            this.log('[set property]', `Skip setting "${property}". Client is not connected`);
+            return false;
         }
+
+        this._client.setProperty(property, value);
+        return true;
     }
 
     reconnect() {

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -82,11 +82,32 @@ class GreeHVACDevice extends Homey.Device {
     onDeleted() {
         this.log('[on deleted]', 'Gree device has been deleted. Disconnecting _client.');
 
+        this._cleanup();
+
+        this.log('[on deleted]', 'Cleanup after removing done');
+    }
+
+    /**
+     * App is shutting down. Same cleanup as removal: the HVAC client owns
+     * its own socket and timers which the SDK does not clean up for us.
+     */
+    async onUninit() {
+        this.log('[on uninit]', 'App is shutting down. Disconnecting _client.');
+
+        this._cleanup();
+
+        this.log('[on uninit]', 'Cleanup done');
+    }
+
+    /**
+     * Stop all timers and disconnect from the HVAC
+     *
+     * @private
+     */
+    _cleanup() {
         this._stopLookingForDevice();
         this._cancelNoResponseReconnect();
         this._tryToDisconnect();
-
-        this.log('[on deleted]', 'Cleanup after removing done');
     }
 
     onSettings({ oldSettings, newSettings, changedKeys }) {

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -17,6 +17,10 @@ const POLLING_TIMEOUT = 3000;
 // Timeout of the connection to the HVAC (ms)
 const CONNECT_TIMEOUT = 5000;
 
+// Time without any response from the HVAC after which
+// the connection is dropped and discovery is restarted (ms)
+const NO_RESPONSE_RECONNECT_TIMEOUT = 60 * 1000;
+
 class GreeHVACDevice extends Homey.Device {
 
     /**
@@ -34,6 +38,14 @@ class GreeHVACDevice extends Homey.Device {
      * @private
      */
     _lookingForDeviceIntervalRef = null;
+
+    /**
+     * Reconnect on prolonged lack of response timeout reference
+     *
+     * @type {NodeJS.Timeout|null}
+     * @private
+     */
+    _noResponseReconnectTimeoutRef = null;
 
     /**
      * Current static IP setting value, including pending updates from onSettings.
@@ -71,6 +83,7 @@ class GreeHVACDevice extends Homey.Device {
         this.log('[on deleted]', 'Gree device has been deleted. Disconnecting _client.');
 
         this._stopLookingForDevice();
+        this._cancelNoResponseReconnect();
         this._tryToDisconnect();
 
         this.log('[on deleted]', 'Cleanup after removing done');
@@ -302,6 +315,7 @@ class GreeHVACDevice extends Homey.Device {
     _onConnect(client) {
         this.log('[connect]', 'connected to', client.getDeviceId());
         this.log('[connect]', 'mark device available');
+        this._cancelNoResponseReconnect();
         this.setAvailable();
     }
 
@@ -328,6 +342,9 @@ class GreeHVACDevice extends Homey.Device {
         //     quiet: 'off',
         //     turbo: 'off',
         //     powerSave: 'off' }
+
+        // The HVAC is responding again
+        this._cancelNoResponseReconnect();
 
         if (!this.getAvailable()) {
             this.log('[update]', 'mark device available');
@@ -490,8 +507,39 @@ class GreeHVACDevice extends Homey.Device {
     _onNoResponse() {
         this.log('[no response]', 'Didn\'t get response during polling updates');
         this._markOffline();
+        this._scheduleNoResponseReconnect();
+    }
 
-        // TODO: Start timeout to do a manual reconnect if no response for long time
+    /**
+     * Schedule a full reconnect if the HVAC keeps not responding.
+     * Covers the case when the HVAC changed its IP address (e.g. via DHCP):
+     * the client would keep polling the old address forever,
+     * so drop the connection and restart discovery instead.
+     *
+     * @private
+     */
+    _scheduleNoResponseReconnect() {
+        if (this._noResponseReconnectTimeoutRef) {
+            return;
+        }
+
+        this._noResponseReconnectTimeoutRef = this.homey.setTimeout(() => {
+            this._noResponseReconnectTimeoutRef = null;
+            this.log('[no response]', 'No response for too long. Reconnecting');
+            this.reconnect();
+        }, NO_RESPONSE_RECONNECT_TIMEOUT);
+    }
+
+    /**
+     * Cancel the scheduled reconnect, e.g. when the HVAC started responding again
+     *
+     * @private
+     */
+    _cancelNoResponseReconnect() {
+        if (this._noResponseReconnectTimeoutRef) {
+            this.homey.clearTimeout(this._noResponseReconnectTimeoutRef);
+            this._noResponseReconnectTimeoutRef = null;
+        }
     }
 
     /**
@@ -745,6 +793,7 @@ class GreeHVACDevice extends Homey.Device {
 
     reconnect() {
         this.log('Reconnecting to the HVAC');
+        this._cancelNoResponseReconnect();
         this._markOffline();
         this._tryToDisconnect();
         this._startLookingForDevice();

--- a/drivers/gree_cooper_hunter_hvac/driver.js
+++ b/drivers/gree_cooper_hunter_hvac/driver.js
@@ -11,6 +11,15 @@ class GreeHVACDriver extends Homey.Driver {
         this._finder = finder;
     }
 
+    /**
+     * App is shutting down. Stop discovery and release the UDP socket,
+     * timers and pending probes held by the finder.
+     */
+    async onUninit() {
+        this.log('GreeHVACDriver is uninitializing. Stopping finder.');
+        this._finder.stop();
+    }
+
     async onPair(session) {
         // Device descriptors added manually via static IP during this pair session
         const staticDevices = [];

--- a/drivers/gree_cooper_hunter_hvac/driver.js
+++ b/drivers/gree_cooper_hunter_hvac/driver.js
@@ -12,17 +12,19 @@ class GreeHVACDriver extends Homey.Driver {
     }
 
     async onPair(session) {
-        // Devices added manually via static IP during this pair session
+        // Device descriptors added manually via static IP during this pair session
         const staticDevices = [];
 
         session.setHandler('list_devices', async () => {
             const staticIpByMac = {};
-            for (const hvac of staticDevices) {
-                staticIpByMac[hvac.message.mac] = hvac.remoteInfo.address;
+            for (const device of staticDevices) {
+                if (device.data.mac) {
+                    staticIpByMac[device.data.mac] = device.settings.static_ip;
+                }
             }
 
             // MACs of already paired devices. Devices paired via "Skip UDP scan"
-            // have an IP as data.mac, so Homey cannot match them by device data
+            // have no MAC in their device data, so Homey cannot match them
             // when they show up in the broadcast results with their real MAC.
             const pairedMacs = new Set(this.getDevices().map((device) => device.getMac()));
 
@@ -37,12 +39,14 @@ class GreeHVACDriver extends Homey.Driver {
 
             // Include static devices not found via broadcast
             const foundMacs = new Set(found.map((d) => d.data.mac));
-            const manual = staticDevices
-                .filter((hvac) => !foundMacs.has(hvac.message.mac) && !pairedMacs.has(hvac.message.mac))
-                .map((hvac) => ({
-                    ...GreeHVACDriver.hvacToDevice(hvac),
-                    settings: { static_ip: hvac.remoteInfo.address },
-                }));
+            const manual = staticDevices.filter((device) => {
+                // Devices without a known MAC ("Skip UDP scan") cannot be deduplicated
+                if (!device.data.mac) {
+                    return true;
+                }
+
+                return !foundMacs.has(device.data.mac) && !pairedMacs.has(device.data.mac);
+            });
 
             return [...found, ...manual];
         });
@@ -54,19 +58,25 @@ class GreeHVACDriver extends Homey.Driver {
 
             const cleanIp = ip.trim();
 
+            let device;
             if (skipScan) {
+                // The device cannot be probed, so its MAC is unknown at pair time.
+                // Use the IP as the unique device id; the real MAC is resolved
+                // and stored by the device on the first successful connection.
                 const deviceName = (name && name.trim()) || cleanIp;
-                const hvac = {
-                    message: { cid: cleanIp, mac: cleanIp, name: deviceName },
-                    remoteInfo: { address: cleanIp },
+                device = {
+                    name: `${deviceName} (${cleanIp})`,
+                    data: {
+                        id: cleanIp,
+                    },
                 };
-                staticDevices.push(hvac);
-                return GreeHVACDriver.hvacToDevice(hvac);
+            } else {
+                device = GreeHVACDriver.hvacToDevice(await finder.probe(cleanIp));
             }
 
-            const hvac = await finder.probe(cleanIp);
-            staticDevices.push(hvac);
-            return GreeHVACDriver.hvacToDevice(hvac);
+            device.settings = { static_ip: cleanIp };
+            staticDevices.push(device);
+            return device;
         });
     }
 

--- a/drivers/gree_cooper_hunter_hvac/driver.js
+++ b/drivers/gree_cooper_hunter_hvac/driver.js
@@ -21,7 +21,12 @@ class GreeHVACDriver extends Homey.Driver {
                 staticIpByMac[hvac.message.mac] = hvac.remoteInfo.address;
             }
 
-            const found = finder.hvacs.map((hvac) => {
+            // MACs of already paired devices. Devices paired via "Skip UDP scan"
+            // have an IP as data.mac, so Homey cannot match them by device data
+            // when they show up in the broadcast results with their real MAC.
+            const pairedMacs = new Set(this.getDevices().map((device) => device.getMac()));
+
+            const found = finder.hvacs.filter((hvac) => !pairedMacs.has(hvac.message.mac)).map((hvac) => {
                 const device = GreeHVACDriver.hvacToDevice(hvac);
                 const staticIp = staticIpByMac[hvac.message.mac];
                 if (staticIp) {
@@ -33,7 +38,7 @@ class GreeHVACDriver extends Homey.Driver {
             // Include static devices not found via broadcast
             const foundMacs = new Set(found.map((d) => d.data.mac));
             const manual = staticDevices
-                .filter((hvac) => !foundMacs.has(hvac.message.mac))
+                .filter((hvac) => !foundMacs.has(hvac.message.mac) && !pairedMacs.has(hvac.message.mac))
                 .map((hvac) => ({
                     ...GreeHVACDriver.hvacToDevice(hvac),
                     settings: { static_ip: hvac.remoteInfo.address },

--- a/drivers/gree_cooper_hunter_hvac/driver.js
+++ b/drivers/gree_cooper_hunter_hvac/driver.js
@@ -2,6 +2,7 @@
 
 const Homey = require('homey');
 const finder = require('./network/finder');
+const { isValidIpv4 } = require('../../utils');
 
 class GreeHVACDriver extends Homey.Driver {
 
@@ -42,7 +43,7 @@ class GreeHVACDriver extends Homey.Driver {
         });
 
         session.setHandler('addStaticDevice', async ({ ip, skipScan, name }) => {
-            if (!GreeHVACDriver.isValidIpv4(ip)) {
+            if (!isValidIpv4(ip)) {
                 throw new Error('Invalid IP address');
             }
 
@@ -61,22 +62,6 @@ class GreeHVACDriver extends Homey.Driver {
             const hvac = await finder.probe(cleanIp);
             staticDevices.push(hvac);
             return GreeHVACDriver.hvacToDevice(hvac);
-        });
-    }
-
-    static isValidIpv4(ip) {
-        if (!ip) {
-            return false;
-        }
-
-        const octets = ip.trim().split('.');
-        return octets.length === 4 && octets.every((octet) => {
-            if (!/^\d+$/.test(octet)) {
-                return false;
-            }
-
-            const value = Number(octet);
-            return value >= 0 && value <= 255;
         });
     }
 

--- a/drivers/gree_cooper_hunter_hvac/network/finder.js
+++ b/drivers/gree_cooper_hunter_hvac/network/finder.js
@@ -149,6 +149,39 @@ class Finder {
     }
 
     /**
+     * Stop discovery and release all resources: the broadcast interval,
+     * a pending restart, pending probes and the UDP socket.
+     * Called when the app is shutting down.
+     */
+    stop() {
+        this._encryptionServiceLogger.info('stop listening');
+
+        clearInterval(this.broadcastInterval);
+
+        if (this._restartTimeoutRef) {
+            clearTimeout(this._restartTimeoutRef);
+            this._restartTimeoutRef = null;
+        }
+
+        if (this._pendingProbes) {
+            for (const ip of Object.keys(this._pendingProbes)) {
+                const probe = this._pendingProbes[ip];
+                clearTimeout(probe.timeoutRef);
+                probe.reject(new Error('Finder is stopping'));
+            }
+            this._pendingProbes = {};
+        }
+
+        this.server.removeAllListeners();
+        try {
+            this.server.close();
+        } catch (error) {
+            // close() throws when the socket is already closed / was never bound
+            this._encryptionServiceLogger.error('failed to close server', { error });
+        }
+    }
+
+    /**
      * Send a unicast scan to a specific IP and resolve with the device info when it responds.
      *
      * @param {string} ip

--- a/drivers/gree_cooper_hunter_hvac/network/finder.js
+++ b/drivers/gree_cooper_hunter_hvac/network/finder.js
@@ -8,6 +8,10 @@ const { randomUUID } = require('crypto');
 const SCAN_MESSAGE = Buffer.from('{"t": "scan"}');
 const THIRTY_SECONDS = 30 * 1000;
 
+// Delay before recreating the socket after an error to avoid a tight
+// error -> restart -> error loop (e.g. when port 7000 is already in use)
+const RESTART_DELAY = 10 * 1000;
+
 class Finder {
 
     constructor() {
@@ -44,8 +48,14 @@ class Finder {
 
     _broadcast() {
         this._encryptionServiceLogger.info('send broadcast message');
-        this.server.setBroadcast(true);
-        this.server.send(SCAN_MESSAGE, 0, SCAN_MESSAGE.length, 7000, '255.255.255.255');
+        try {
+            this.server.setBroadcast(true);
+            this.server.send(SCAN_MESSAGE, 0, SCAN_MESSAGE.length, 7000, '255.255.255.255');
+        } catch (error) {
+            // setBroadcast()/send() throw when the socket is not bound or already
+            // closed. An uncaught exception here would crash the whole app.
+            this._encryptionServiceLogger.error('failed to send broadcast message', { error });
+        }
     }
 
     _onMessage(message, remoteInfo) {
@@ -118,10 +128,24 @@ class Finder {
 
     _restart(reason) {
         this._encryptionServiceLogger.error('restart server', { reason });
-        clearInterval(this.broadcastInterval);
-        this.server.close();
 
-        this.start();
+        if (this._restartTimeoutRef) {
+            return;
+        }
+
+        clearInterval(this.broadcastInterval);
+        this.server.removeAllListeners();
+        try {
+            this.server.close();
+        } catch (error) {
+            // close() throws when the socket is already closed / was never bound
+            this._encryptionServiceLogger.error('failed to close server', { error });
+        }
+
+        this._restartTimeoutRef = setTimeout(() => {
+            this._restartTimeoutRef = null;
+            this.start();
+        }, RESTART_DELAY);
     }
 
     /**
@@ -159,7 +183,16 @@ class Finder {
             timeoutRef,
         };
 
-        this.server.send(SCAN_MESSAGE, 0, SCAN_MESSAGE.length, 7000, ip);
+        try {
+            this.server.send(SCAN_MESSAGE, 0, SCAN_MESSAGE.length, 7000, ip);
+        } catch (error) {
+            // send() throws when the socket is closed (e.g. during a restart).
+            // Without this, the throw would leave a pending probe behind whose
+            // timeout later rejects a promise nobody holds anymore.
+            clearTimeout(timeoutRef);
+            delete this._pendingProbes[ip];
+            rejectProbe(error);
+        }
 
         return promise;
     }

--- a/locales/en.json
+++ b/locales/en.json
@@ -15,6 +15,7 @@
         }
     },
     "error": {
-        "offline": "Your HVAC went offline. Trying to reconnect..."
+        "offline": "Your HVAC went offline. Trying to reconnect...",
+        "invalid_static_ip": "Invalid IP address. Enter a valid IPv4 address or leave the field empty to use auto-discovery."
     }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -15,6 +15,7 @@
         }
     },
     "error": {
-        "offline": "Je Airco is offline gegaan. Aan het proberen opnieuw te verbinden..."
+        "offline": "Je Airco is offline gegaan. Aan het proberen opnieuw te verbinden...",
+        "invalid_static_ip": "Ongeldig IP-adres. Voer een geldig IPv4-adres in of laat het veld leeg om automatische detectie te gebruiken."
     }
 }

--- a/test/device.disconnect.test.js
+++ b/test/device.disconnect.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+describe('GreeHVACDevice._tryToDisconnect()', () => {
+    let GreeHVACDevice;
+    let device;
+
+    beforeEach(() => {
+        jest.resetModules();
+
+        jest.doMock('../drivers/gree_cooper_hunter_hvac/network/finder', () => ({ hvacs: [] }));
+
+        jest.doMock('gree-hvac-client', () => ({
+            PROPERTY: {},
+            VALUE: {},
+        }));
+
+        jest.doMock('homey', () => ({
+            Device: class Device {
+                log() {}
+                error() {}
+            },
+        }));
+
+        GreeHVACDevice = require('../drivers/gree_cooper_hunter_hvac/device');
+
+        device = new GreeHVACDevice();
+        device.log = jest.fn();
+        device.error = jest.fn();
+    });
+
+    test('handles disconnect() rejection instead of leaving it unhandled', async () => {
+        const rejection = new Error('Client is not connected to the HVAC');
+        device._client = {
+            removeAllListeners: jest.fn(),
+            disconnect: jest.fn().mockRejectedValue(rejection),
+        };
+
+        device._tryToDisconnect();
+
+        expect(device._client).toBeNull();
+
+        // Flush microtasks so the rejection is delivered
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(device.error).toHaveBeenCalledWith(rejection);
+    });
+
+    test('removes listeners before disconnecting and clears the client', () => {
+        const client = {
+            removeAllListeners: jest.fn(),
+            disconnect: jest.fn().mockResolvedValue(),
+        };
+        device._client = client;
+
+        device._tryToDisconnect();
+
+        expect(client.removeAllListeners).toHaveBeenCalled();
+        expect(client.disconnect).toHaveBeenCalled();
+        expect(device._client).toBeNull();
+    });
+
+    test('does nothing when there is no client', () => {
+        device._client = null;
+
+        expect(() => device._tryToDisconnect()).not.toThrow();
+    });
+});

--- a/test/device.findDevices.test.js
+++ b/test/device.findDevices.test.js
@@ -117,6 +117,28 @@ describe('GreeHVACDevice._findDevices()', () => {
         expect(device._staticIpSetting).toBe('192.168.1.51');
     });
 
+    test('rejects an invalid static IP and does not reconnect', () => {
+        device.reconnect = jest.fn();
+        device.homey = { __: jest.fn((key) => key) };
+
+        expect(() => device.onSettings({
+            oldSettings: { static_ip: '' },
+            newSettings: { static_ip: 'not-an-ip' },
+            changedKeys: ['static_ip'],
+        })).toThrow('error.invalid_static_ip');
+
+        expect(device.reconnect).not.toHaveBeenCalled();
+        expect(device._staticIpSetting).toBeUndefined();
+    });
+
+    test('find devices trims whitespace around the static IP setting', () => {
+        device.getSetting = jest.fn(() => '  192.168.1.50  ');
+
+        device._findDevices();
+
+        expect(device._connectToHost).toHaveBeenCalledWith('192.168.1.50');
+    });
+
     test('does not reconnect when static IP setting value is unchanged', () => {
         device.reconnect = jest.fn();
 

--- a/test/device.findDevices.test.js
+++ b/test/device.findDevices.test.js
@@ -30,6 +30,7 @@ describe('GreeHVACDevice._findDevices()', () => {
         device = new GreeHVACDevice();
         device._client = null;
         device.getData = jest.fn(() => ({ id: 'aabb', mac: 'aabb' }));
+        device.getStoreValue = jest.fn(() => null);
         device.getSetting = jest.fn(() => '');
         device.log = jest.fn();
         device._stopLookingForDevice = jest.fn();

--- a/test/device.flowTriggers.test.js
+++ b/test/device.flowTriggers.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+describe('GreeHVACDevice flow triggers from capability listeners', () => {
+    let GreeHVACDevice;
+    let device;
+    let capabilityListeners;
+
+    beforeEach(() => {
+        jest.resetModules();
+
+        capabilityListeners = {};
+
+        jest.doMock('../drivers/gree_cooper_hunter_hvac/network/finder', () => ({ hvacs: [] }));
+
+        jest.doMock('gree-hvac-client', () => ({
+            PROPERTY: { fanSpeed: 'fanSpeed', turbo: 'turbo' },
+            VALUE: {
+                fanSpeed: { low: 'low', high: 'high' },
+                turbo: { on: 'on', off: 'off' },
+            },
+        }));
+
+        jest.doMock('homey', () => ({
+            Device: class Device {
+                log() {}
+                error() {}
+            },
+        }));
+
+        GreeHVACDevice = require('../drivers/gree_cooper_hunter_hvac/device');
+
+        device = new GreeHVACDevice();
+        device.registerCapabilityListener = jest.fn((capability, listener) => {
+            capabilityListeners[capability] = listener;
+        });
+        device.log = jest.fn();
+        device._flowTriggerHvacFanSpeedChanged = { trigger: jest.fn() };
+        device._flowTriggerTurboModeChanged = { trigger: jest.fn() };
+
+        device._registerCapabilityListeners();
+    });
+
+    test('fires the trigger when the command is sent to the HVAC', async () => {
+        device._client = { setProperty: jest.fn() };
+
+        await capabilityListeners.fan_speed('low');
+
+        expect(device._client.setProperty).toHaveBeenCalledWith('fanSpeed', 'low');
+        expect(device._flowTriggerHvacFanSpeedChanged.trigger)
+            .toHaveBeenCalledWith(device, { fan_speed: 'low' });
+    });
+
+    test('does not fire the trigger when the client is not connected', async () => {
+        device._client = null;
+
+        await capabilityListeners.fan_speed('low');
+        await capabilityListeners.turbo_mode(true);
+
+        expect(device._flowTriggerHvacFanSpeedChanged.trigger).not.toHaveBeenCalled();
+        expect(device._flowTriggerTurboModeChanged.trigger).not.toHaveBeenCalled();
+    });
+});

--- a/test/device.macResolution.test.js
+++ b/test/device.macResolution.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+describe('GreeHVACDevice MAC resolution for "Skip UDP scan" devices', () => {
+    let GreeHVACDevice;
+    let mockFinder;
+    let device;
+
+    beforeEach(() => {
+        jest.resetModules();
+
+        mockFinder = { hvacs: [] };
+
+        jest.doMock('../drivers/gree_cooper_hunter_hvac/network/finder', () => mockFinder);
+
+        jest.doMock('gree-hvac-client', () => ({
+            PROPERTY: {},
+            VALUE: {},
+        }));
+
+        jest.doMock('homey', () => ({
+            Device: class Device {
+                log() {}
+                error() {}
+            },
+        }));
+
+        GreeHVACDevice = require('../drivers/gree_cooper_hunter_hvac/device');
+
+        device = new GreeHVACDevice();
+        device.log = jest.fn();
+        device.error = jest.fn();
+        device.getData = jest.fn(() => ({ id: '192.168.1.50', mac: '192.168.1.50' }));
+        device.getStoreValue = jest.fn(() => null);
+        device.setStoreValue = jest.fn().mockResolvedValue();
+        device.setAvailable = jest.fn();
+        device._cancelNoResponseReconnect = jest.fn();
+    });
+
+    describe('getMac()', () => {
+        test('falls back to device data when no MAC is stored', () => {
+            expect(device.getMac()).toBe('192.168.1.50');
+        });
+
+        test('prefers the resolved MAC from the store', () => {
+            device.getStoreValue = jest.fn(() => 'aabbccddeeff');
+
+            expect(device.getMac()).toBe('aabbccddeeff');
+            expect(device.getStoreValue).toHaveBeenCalledWith('mac');
+        });
+    });
+
+    describe('_onConnect()', () => {
+        test('stores the real MAC when it differs from device data', () => {
+            const client = { getDeviceId: jest.fn(() => 'aabbccddeeff') };
+
+            device._onConnect(client);
+
+            expect(device.setStoreValue).toHaveBeenCalledWith('mac', 'aabbccddeeff');
+        });
+
+        test('does not touch the store when the MAC is already known', () => {
+            device.getData = jest.fn(() => ({ id: 'aabbccddeeff', mac: 'aabbccddeeff' }));
+            const client = { getDeviceId: jest.fn(() => 'aabbccddeeff') };
+
+            device._onConnect(client);
+
+            expect(device.setStoreValue).not.toHaveBeenCalled();
+        });
+
+        test('ignores an empty device id from the client', () => {
+            const client = { getDeviceId: jest.fn(() => null) };
+
+            device._onConnect(client);
+
+            expect(device.setStoreValue).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('_findDevices()', () => {
+        test('matches finder results against the resolved MAC', () => {
+            device.getStoreValue = jest.fn(() => 'aabbccddeeff');
+            device.getSetting = jest.fn(() => '');
+            device._stopLookingForDevice = jest.fn();
+            device._connectToHost = jest.fn();
+            mockFinder.hvacs = [
+                { message: { mac: 'aabbccddeeff' }, remoteInfo: { address: '10.0.0.7' } },
+            ];
+
+            device._findDevices();
+
+            expect(device._connectToHost).toHaveBeenCalledWith('10.0.0.7');
+        });
+    });
+});

--- a/test/device.macResolution.test.js
+++ b/test/device.macResolution.test.js
@@ -67,6 +67,16 @@ describe('GreeHVACDevice MAC resolution for "Skip UDP scan" devices', () => {
             expect(device.setStoreValue).not.toHaveBeenCalled();
         });
 
+        test('never overwrites a real MAC obtained during pairing', () => {
+            device.getData = jest.fn(() => ({ id: 'aabbccddeeff', mac: 'aabbccddeeff' }));
+            // Client cid is not guaranteed to equal the broadcast MAC
+            const client = { getDeviceId: jest.fn(() => 'different-cid') };
+
+            device._onConnect(client);
+
+            expect(device.setStoreValue).not.toHaveBeenCalled();
+        });
+
         test('ignores an empty device id from the client', () => {
             const client = { getDeviceId: jest.fn(() => null) };
 

--- a/test/device.macResolution.test.js
+++ b/test/device.macResolution.test.js
@@ -90,5 +90,20 @@ describe('GreeHVACDevice MAC resolution for "Skip UDP scan" devices', () => {
 
             expect(device._connectToHost).toHaveBeenCalledWith('10.0.0.7');
         });
+
+        test('skips discovery when the MAC is not known yet', () => {
+            // Paired via "Skip UDP scan": no MAC in device data, none resolved yet
+            device.getData = jest.fn(() => ({ id: '192.168.1.50' }));
+            device.getSetting = jest.fn(() => '');
+            device._stopLookingForDevice = jest.fn();
+            device._connectToHost = jest.fn();
+            mockFinder.hvacs = [
+                { message: { mac: 'aabbccddeeff' }, remoteInfo: { address: '10.0.0.7' } },
+            ];
+
+            device._findDevices();
+
+            expect(device._connectToHost).not.toHaveBeenCalled();
+        });
     });
 });

--- a/test/device.noResponseReconnect.test.js
+++ b/test/device.noResponseReconnect.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+describe('GreeHVACDevice reconnect on prolonged no response', () => {
+    let GreeHVACDevice;
+    let device;
+
+    beforeEach(() => {
+        jest.resetModules();
+        jest.useFakeTimers();
+
+        jest.doMock('../drivers/gree_cooper_hunter_hvac/network/finder', () => ({ hvacs: [] }));
+
+        jest.doMock('gree-hvac-client', () => ({
+            PROPERTY: { power: 'power', mode: 'mode', temperature: 'temperature' },
+            VALUE: { power: { on: 'on', off: 'off' } },
+        }));
+
+        jest.doMock('homey', () => ({
+            Device: class Device {
+                log() {}
+                error() {}
+            },
+        }));
+
+        GreeHVACDevice = require('../drivers/gree_cooper_hunter_hvac/device');
+
+        device = new GreeHVACDevice();
+        device.homey = {
+            setTimeout: (fn, ms) => setTimeout(fn, ms),
+            clearTimeout: (ref) => clearTimeout(ref),
+        };
+        device.log = jest.fn();
+        device.getAvailable = jest.fn(() => true);
+        device._markOffline = jest.fn();
+        device.reconnect = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('reconnects when the HVAC keeps not responding', () => {
+        device._onNoResponse();
+
+        jest.advanceTimersByTime(60 * 1000);
+
+        expect(device.reconnect).toHaveBeenCalledTimes(1);
+    });
+
+    test('schedules only one reconnect for consecutive no_response events', () => {
+        device._onNoResponse();
+        jest.advanceTimersByTime(30 * 1000);
+        device._onNoResponse();
+
+        // 60s after the FIRST no_response the reconnect should fire once
+        jest.advanceTimersByTime(30 * 1000);
+        expect(device.reconnect).toHaveBeenCalledTimes(1);
+
+        jest.advanceTimersByTime(60 * 1000);
+        expect(device.reconnect).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not reconnect when the HVAC starts responding again', () => {
+        device._onNoResponse();
+        jest.advanceTimersByTime(30 * 1000);
+
+        // Any update from the HVAC cancels the scheduled reconnect
+        device._onUpdate({}, {});
+
+        jest.advanceTimersByTime(120 * 1000);
+        expect(device.reconnect).not.toHaveBeenCalled();
+    });
+
+    test('reconnect() cancels a pending no-response reconnect', () => {
+        const { reconnect } = GreeHVACDevice.prototype;
+        device._markOffline = jest.fn();
+        device._tryToDisconnect = jest.fn();
+        device._startLookingForDevice = jest.fn();
+
+        device._onNoResponse();
+        reconnect.call(device);
+
+        expect(device._noResponseReconnectTimeoutRef).toBeNull();
+        expect(jest.getTimerCount()).toBe(0);
+    });
+});

--- a/test/device.powerListeners.test.js
+++ b/test/device.powerListeners.test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+describe('GreeHVACDevice onoff/thermostat_mode listeners', () => {
+    let GreeHVACDevice;
+    let device;
+    let capabilityListeners;
+
+    beforeEach(() => {
+        jest.resetModules();
+
+        capabilityListeners = {};
+
+        jest.doMock('../drivers/gree_cooper_hunter_hvac/network/finder', () => ({ hvacs: [] }));
+
+        jest.doMock('gree-hvac-client', () => ({
+            PROPERTY: { power: 'power', mode: 'mode', temperature: 'temperature' },
+            VALUE: {
+                power: { on: 'on', off: 'off' },
+                mode: { auto: 'auto', cool: 'cool', heat: 'heat' },
+            },
+        }));
+
+        jest.doMock('homey', () => ({
+            Device: class Device {
+                log() {}
+                error() {}
+            },
+        }));
+
+        GreeHVACDevice = require('../drivers/gree_cooper_hunter_hvac/device');
+
+        device = new GreeHVACDevice();
+        device.registerCapabilityListener = jest.fn((capability, listener) => {
+            capabilityListeners[capability] = listener;
+        });
+        device.setCapabilityValue = jest.fn().mockResolvedValue();
+        device.log = jest.fn();
+        device.error = jest.fn();
+
+        device._registerCapabilityListeners();
+    });
+
+    describe('when the client is not connected', () => {
+        beforeEach(() => {
+            device._client = null;
+        });
+
+        test('turning on does not throw', async () => {
+            await expect(capabilityListeners.onoff(true)).resolves.toBeUndefined();
+
+            // No known mode to restore, so thermostat_mode should stay untouched
+            expect(device.setCapabilityValue).not.toHaveBeenCalledWith('thermostat_mode', expect.anything());
+        });
+
+        test('turning off does not throw and sets thermostat_mode to off', async () => {
+            await expect(capabilityListeners.onoff(false)).resolves.toBeUndefined();
+
+            expect(device.setCapabilityValue).toHaveBeenCalledWith('thermostat_mode', 'off');
+        });
+
+        test('changing thermostat_mode does not throw', async () => {
+            await expect(capabilityListeners.thermostat_mode('cool')).resolves.toBeUndefined();
+        });
+    });
+
+    describe('when the client is connected', () => {
+        beforeEach(() => {
+            device._client = {
+                setProperty: jest.fn(),
+                _properties: { Pow: 0, Mod: 1 },
+                _transformer: {
+                    fromVendor: jest.fn(() => ({ power: 'off', mode: 'cool' })),
+                },
+            };
+        });
+
+        test('turning on restores thermostat_mode from the client state', async () => {
+            await capabilityListeners.onoff(true);
+
+            expect(device._client.setProperty).toHaveBeenCalledWith('power', 'on');
+            expect(device.setCapabilityValue).toHaveBeenCalledWith('thermostat_mode', 'cool');
+        });
+
+        test('changing thermostat_mode turns the HVAC on when it is off', async () => {
+            await capabilityListeners.thermostat_mode('heat');
+
+            expect(device._client.setProperty).toHaveBeenCalledWith('mode', 'heat');
+            expect(device._client.setProperty).toHaveBeenCalledWith('power', 'on');
+            expect(device.setCapabilityValue).toHaveBeenCalledWith('onoff', true);
+        });
+    });
+});

--- a/test/device.uninit.test.js
+++ b/test/device.uninit.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+describe('GreeHVACDevice cleanup on removal and app shutdown', () => {
+    let GreeHVACDevice;
+    let device;
+
+    beforeEach(() => {
+        jest.resetModules();
+
+        jest.doMock('../drivers/gree_cooper_hunter_hvac/network/finder', () => ({ hvacs: [] }));
+
+        jest.doMock('gree-hvac-client', () => ({
+            PROPERTY: {},
+            VALUE: {},
+        }));
+
+        jest.doMock('homey', () => ({
+            Device: class Device {
+                log() {}
+                error() {}
+            },
+        }));
+
+        GreeHVACDevice = require('../drivers/gree_cooper_hunter_hvac/device');
+
+        device = new GreeHVACDevice();
+        device.log = jest.fn();
+        device.error = jest.fn();
+        device.homey = {
+            clearInterval: jest.fn((ref) => clearInterval(ref)),
+            clearTimeout: jest.fn((ref) => clearTimeout(ref)),
+        };
+    });
+
+    function setupResources() {
+        const client = {
+            removeAllListeners: jest.fn(),
+            disconnect: jest.fn().mockResolvedValue(),
+        };
+        device._client = client;
+        device._lookingForDeviceIntervalRef = setInterval(() => {}, 1000);
+        device._noResponseReconnectTimeoutRef = setTimeout(() => {}, 1000);
+        return client;
+    }
+
+    afterEach(() => {
+        if (device._lookingForDeviceIntervalRef) {
+            clearInterval(device._lookingForDeviceIntervalRef);
+        }
+        if (device._noResponseReconnectTimeoutRef) {
+            clearTimeout(device._noResponseReconnectTimeoutRef);
+        }
+    });
+
+    test('onUninit stops timers and disconnects the client', async () => {
+        const client = setupResources();
+
+        await device.onUninit();
+
+        expect(device._lookingForDeviceIntervalRef).toBeNull();
+        expect(device._noResponseReconnectTimeoutRef).toBeNull();
+        expect(client.removeAllListeners).toHaveBeenCalled();
+        expect(client.disconnect).toHaveBeenCalled();
+        expect(device._client).toBeNull();
+    });
+
+    test('onDeleted stops timers and disconnects the client', () => {
+        const client = setupResources();
+
+        device.onDeleted();
+
+        expect(device._lookingForDeviceIntervalRef).toBeNull();
+        expect(device._noResponseReconnectTimeoutRef).toBeNull();
+        expect(client.removeAllListeners).toHaveBeenCalled();
+        expect(client.disconnect).toHaveBeenCalled();
+        expect(device._client).toBeNull();
+    });
+
+    test('onUninit is safe when nothing was ever started', async () => {
+        await expect(device.onUninit()).resolves.toBeUndefined();
+    });
+});

--- a/test/driver.pair.test.js
+++ b/test/driver.pair.test.js
@@ -5,6 +5,7 @@ describe('GreeHVACDriver.onPair()', () => {
     let mockFinder;
     let session;
     let handlers;
+    let pairedDevices;
 
     beforeEach(() => {
         jest.resetModules();
@@ -25,6 +26,7 @@ describe('GreeHVACDriver.onPair()', () => {
         GreeHVACDriver = require('../drivers/gree_cooper_hunter_hvac/driver');
 
         handlers = {};
+        pairedDevices = [];
         session = {
             setHandler: jest.fn((name, fn) => {
                 handlers[name] = fn;
@@ -32,8 +34,13 @@ describe('GreeHVACDriver.onPair()', () => {
         };
     });
 
+    function makePairedDevice(mac) {
+        return { getMac: jest.fn(() => mac) };
+    }
+
     async function initPair() {
         const driver = new GreeHVACDriver();
+        driver.getDevices = jest.fn(() => pairedDevices);
         await driver.onPair(session);
     }
 
@@ -183,6 +190,38 @@ describe('GreeHVACDriver.onPair()', () => {
             const devices = await handlers.list_devices();
 
             expect(devices).toHaveLength(1);
+        });
+
+        test('excludes broadcast devices that are already paired (by resolved MAC)', async () => {
+            // Device was paired via "Skip UDP scan" (data.mac is an IP),
+            // but its real MAC was resolved on first connect
+            pairedDevices = [makePairedDevice('aabb')];
+            mockFinder.hvacs = [
+                { message: { cid: 'aabb', mac: 'aabb', name: 'Living' }, remoteInfo: { address: '10.0.0.1' } },
+                { message: { cid: 'ccdd', mac: 'ccdd', name: 'Bedroom' }, remoteInfo: { address: '10.0.0.2' } },
+            ];
+
+            await initPair();
+
+            const devices = await handlers.list_devices();
+
+            expect(devices).toHaveLength(1);
+            expect(devices[0].data.mac).toBe('ccdd');
+        });
+
+        test('excludes manually added devices that are already paired', async () => {
+            pairedDevices = [makePairedDevice('ccdd')];
+            await initPair();
+
+            mockFinder.probe.mockResolvedValue({
+                message: { cid: 'ccdd', mac: 'ccdd', name: 'Bedroom' },
+                remoteInfo: { address: '10.0.0.2' },
+            });
+            await handlers.addStaticDevice({ ip: '10.0.0.2', skipScan: false });
+
+            const devices = await handlers.list_devices();
+
+            expect(devices).toHaveLength(0);
         });
 
         test('returns both broadcast and unique static devices', async () => {

--- a/test/driver.pair.test.js
+++ b/test/driver.pair.test.js
@@ -97,14 +97,15 @@ describe('GreeHVACDriver.onPair()', () => {
             expect(mockFinder.probe).not.toHaveBeenCalled();
         });
 
-        test('uses IP as id, mac, and name when skipScan is true and no name given', async () => {
+        test('uses IP as id and name but no MAC when skipScan is true and no name given', async () => {
             await initPair();
 
             const result = await handlers.addStaticDevice({ ip: '192.168.1.10', skipScan: true, name: '' });
 
             expect(result.data.id).toBe('192.168.1.10');
-            expect(result.data.mac).toBe('192.168.1.10');
+            expect(result.data.mac).toBeUndefined();
             expect(result.name).toBe('192.168.1.10 (192.168.1.10)');
+            expect(result.settings.static_ip).toBe('192.168.1.10');
         });
 
         test('uses provided name when skipScan is true and name is given', async () => {
@@ -235,6 +236,18 @@ describe('GreeHVACDriver.onPair()', () => {
             const devices = await handlers.list_devices();
 
             expect(devices).toHaveLength(2);
+        });
+
+        test('always includes skipScan devices since they cannot be deduplicated', async () => {
+            pairedDevices = [makePairedDevice('aabb')];
+            await initPair();
+
+            await handlers.addStaticDevice({ ip: '10.0.0.2', skipScan: true, name: 'Bedroom' });
+
+            const devices = await handlers.list_devices();
+
+            expect(devices).toHaveLength(1);
+            expect(devices[0].data.id).toBe('10.0.0.2');
         });
     });
 });

--- a/test/finder.restart.test.js
+++ b/test/finder.restart.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const EventEmitter = require('events');
+
+describe('Finder error handling', () => {
+    let finder;
+    let sockets;
+    let createSocket;
+
+    function makeFakeSocket() {
+        const socket = new EventEmitter();
+        socket.bind = jest.fn(() => {
+            process.nextTick(() => socket.emit('listening'));
+        });
+        socket.setBroadcast = jest.fn();
+        socket.send = jest.fn();
+        socket.close = jest.fn();
+        return socket;
+    }
+
+    beforeEach(() => {
+        jest.resetModules();
+        jest.useFakeTimers();
+
+        sockets = [];
+        createSocket = jest.fn(() => {
+            const socket = makeFakeSocket();
+            sockets.push(socket);
+            return socket;
+        });
+
+        jest.doMock('dgram', () => ({
+            createSocket,
+        }));
+
+        jest.doMock('gree-hvac-client/src/encryption-service', () => ({
+            EcbCipher: jest.fn().mockImplementation(() => ({ decrypt: jest.fn() })),
+            GcmCipher: jest.fn().mockImplementation(() => ({ decrypt: jest.fn() })),
+        }));
+
+        jest.doMock('gree-hvac-client/src/logger', () => ({
+            createLogger: jest.fn(() => ({
+                info: jest.fn(),
+                error: jest.fn(),
+                child: jest.fn().mockReturnThis(),
+            })),
+        }));
+
+        finder = require('../drivers/gree_cooper_hunter_hvac/network/finder');
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('recreates the socket after an error, with a delay', () => {
+        expect(sockets).toHaveLength(1);
+
+        sockets[0].emit('error', new Error('EADDRINUSE'));
+
+        // Not restarted immediately
+        expect(sockets).toHaveLength(1);
+
+        jest.advanceTimersByTime(10 * 1000);
+
+        expect(sockets).toHaveLength(2);
+        expect(sockets[0].close).toHaveBeenCalled();
+        expect(sockets[1].bind).toHaveBeenCalledWith(7000);
+    });
+
+    test('does not schedule multiple restarts for repeated errors', () => {
+        sockets[0].emit('error', new Error('first'));
+        finder._restart(new Error('second'));
+        finder._restart(new Error('third'));
+
+        jest.advanceTimersByTime(30 * 1000);
+
+        expect(sockets).toHaveLength(2);
+    });
+
+    test('survives close() throwing during restart', () => {
+        sockets[0].close.mockImplementation(() => {
+            throw new Error('Not running');
+        });
+
+        expect(() => sockets[0].emit('error', new Error('boom'))).not.toThrow();
+
+        jest.advanceTimersByTime(10 * 1000);
+        expect(sockets).toHaveLength(2);
+    });
+
+    test('broadcast failures do not throw', () => {
+        sockets[0].setBroadcast.mockImplementation(() => {
+            throw new Error('Not running');
+        });
+
+        expect(() => finder._broadcast()).not.toThrow();
+    });
+
+    test('probe rejects cleanly when send throws on a closed socket', async () => {
+        sockets[0].send.mockImplementation(() => {
+            throw new Error('Not running');
+        });
+
+        await expect(finder.probe('192.168.1.50')).rejects.toThrow('Not running');
+
+        // The pending probe must be cleaned up so no orphaned timeout remains
+        expect(finder._pendingProbes['192.168.1.50']).toBeUndefined();
+    });
+});

--- a/test/finder.stop.test.js
+++ b/test/finder.stop.test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const EventEmitter = require('events');
+
+describe('Finder stop', () => {
+    let finder;
+    let sockets;
+    let createSocket;
+
+    function makeFakeSocket() {
+        const socket = new EventEmitter();
+        socket.bind = jest.fn(() => {
+            process.nextTick(() => socket.emit('listening'));
+        });
+        socket.setBroadcast = jest.fn();
+        socket.send = jest.fn();
+        socket.close = jest.fn();
+        return socket;
+    }
+
+    beforeEach(() => {
+        jest.resetModules();
+        jest.useFakeTimers();
+
+        sockets = [];
+        createSocket = jest.fn(() => {
+            const socket = makeFakeSocket();
+            sockets.push(socket);
+            return socket;
+        });
+
+        jest.doMock('dgram', () => ({
+            createSocket,
+        }));
+
+        jest.doMock('gree-hvac-client/src/encryption-service', () => ({
+            EcbCipher: jest.fn().mockImplementation(() => ({ decrypt: jest.fn() })),
+            GcmCipher: jest.fn().mockImplementation(() => ({ decrypt: jest.fn() })),
+        }));
+
+        jest.doMock('gree-hvac-client/src/logger', () => ({
+            createLogger: jest.fn(() => ({
+                info: jest.fn(),
+                error: jest.fn(),
+                child: jest.fn().mockReturnThis(),
+            })),
+        }));
+
+        finder = require('../drivers/gree_cooper_hunter_hvac/network/finder');
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('closes the socket and stops broadcasting', () => {
+        // Let the socket emit 'listening' so the broadcast interval is set
+        jest.runOnlyPendingTimers();
+        sockets[0].send.mockClear();
+
+        finder.stop();
+
+        expect(sockets[0].close).toHaveBeenCalled();
+
+        jest.advanceTimersByTime(60 * 1000);
+        expect(sockets[0].send).not.toHaveBeenCalled();
+    });
+
+    test('cancels a pending restart', () => {
+        sockets[0].emit('error', new Error('boom'));
+
+        finder.stop();
+
+        jest.advanceTimersByTime(60 * 1000);
+
+        // No new socket was created by the pending restart
+        expect(sockets).toHaveLength(1);
+    });
+
+    test('rejects pending probes', async () => {
+        const probe = finder.probe('192.168.1.50');
+
+        finder.stop();
+
+        await expect(probe).rejects.toThrow('Finder is stopping');
+        expect(finder._pendingProbes['192.168.1.50']).toBeUndefined();
+    });
+
+    test('survives close() throwing when the socket is already closed', () => {
+        sockets[0].close.mockImplementation(() => {
+            throw new Error('Not running');
+        });
+
+        expect(() => finder.stop()).not.toThrow();
+    });
+});

--- a/test/utils.isValidIpv4.test.js
+++ b/test/utils.isValidIpv4.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { isValidIpv4 } = require('../utils');
+
+describe('isValidIpv4()', () => {
+    test('accepts valid IPv4 addresses', () => {
+        const validIps = [
+            '192.168.1.1',
+            '10.0.0.5',
+            '0.0.0.0',
+            '255.255.255.255',
+            '  192.168.1.1  ',
+        ];
+
+        for (const ip of validIps) {
+            expect(isValidIpv4(ip)).toBe(true);
+        }
+    });
+
+    test('rejects invalid IPv4 addresses', () => {
+        const invalidIps = [
+            '',
+            null,
+            undefined,
+            'not-an-ip',
+            '192.168.1',
+            '192.168.1.1.1',
+            '256.1.1.1',
+            '192.168.1.999',
+            '192.168.-1.1',
+            '01.2.3.4',
+            '1.2.3.04',
+            '1.2.3.4a',
+        ];
+
+        for (const ip of invalidIps) {
+            expect(isValidIpv4(ip)).toBe(false);
+        }
+    });
+});

--- a/utils/index.js
+++ b/utils/index.js
@@ -15,6 +15,33 @@ function compareBoolProperties(propertyValue, capabilityValue, trueValue) {
     return changedFromFalseToTrue || changedFromTrueToFalse;
 }
 
+/**
+ * Check that the given string is a valid IPv4 address
+ *
+ * @param {string} ip
+ * @returns {boolean}
+ */
+function isValidIpv4(ip) {
+    if (!ip) {
+        return false;
+    }
+
+    const octets = ip.trim().split('.');
+    return octets.length === 4 && octets.every((octet) => {
+        if (!/^\d+$/.test(octet)) {
+            return false;
+        }
+
+        // Reject leading zeros ("01") which dgram may treat as octal
+        if (String(Number(octet)) !== octet) {
+            return false;
+        }
+
+        return Number(octet) <= 255;
+    });
+}
+
 module.exports = {
     compareBoolProperties,
+    isValidIpv4,
 };


### PR DESCRIPTION
This PR fixes eight bugs found during a code review of the app. Each fix is a separate commit with tests. All 74 tests and eslint pass.

## 1. Crash when changing power/mode while the HVAC is disconnected

The `onoff` and `thermostat_mode` capability listeners accessed `this._client._transformer.fromVendor(this._client._properties)` without a null check. `_client` is `null` while the device is still being discovered or is reconnecting (e.g. right after a static IP change), so turning the device **on** from the UI — or via the `set_hvac_mode` flow action, which calls `triggerCapabilityListener` — threw:

```
TypeError: Cannot read properties of null (reading '_transformer')
```

Notably `_setClientProperty` already guarded against a null client; these two code paths did not. Client property access now goes through a `_getCurrentClientProperties()` helper that returns `{}` when there is no client. Also added missing `.catch(this.error)` to the fire-and-forget `setCapabilityValue` calls in those listeners.

## 2. Device never recovered when its IP changed (DHCP)

Once connected, discovery stopped permanently. If the HVAC later got a new IP from DHCP, the client kept polling the dead address forever: `no_response` marked the device unavailable, but nothing dropped the connection or restarted discovery — the device stayed offline until an app restart. This resolves the long-standing `TODO` in `_onNoResponse()`.

Now the first `no_response` schedules a full reconnect after 60 s. Any successful update/connect cancels it, so a transient single-poll timeout (Wi-Fi blip) causes no churn. When it fires, the client is disconnected and MAC-based discovery (or the static-IP connect) starts over and picks up the new address.

## 3. `*_changed` flow triggers fired for changes that never happened

Eight capability listeners (`fan_speed`, `turbo_mode`, `safety_heating`, `lights`, `xfan_mode`, `vertical_swing`, `horizontal_swing`, `quiet_mode`) fired their flow trigger cards unconditionally — even when the command was silently dropped because the client was disconnected. A user flow like "when fan speed changed → …" ran although nothing changed on the unit.

`_setClientProperty` now returns whether the command was actually sent, and listeners only fire their trigger in that case. Externally-made changes (IR remote) are unaffected — those triggers keep coming from `_onUpdate` when the HVAC reports its new state.

## 4. Unhandled promise rejection in `_tryToDisconnect`

`gree-hvac-client`'s `disconnect()` returns a promise that **rejects** with `ClientNotConnectedError` when the client has no active socket (possible mid-reconnect-cycle). The result was ignored; on Node 16+ an unhandled rejection terminates the process. `_tryToDisconnect` is reachable from device deletion, static-IP changes and (with this PR) no-response recovery. Now handled with `.catch(this.error)`.

## 5. Finder could crash the app or spin on socket errors

- `_restart()` called `server.close()` unguarded — `close()` throws on an already-closed socket, and an exception inside a socket `'error'` handler is uncaught and takes down the whole app.
- Restart was immediate: a persistent bind failure (port 7000 occupied by another Gree integration) produced a tight error→restart→error loop. Restarts are now debounced and delayed by 10 s, and the old socket's listeners are detached.
- `_broadcast()` called `setBroadcast()`/`send()` unguarded from a 30 s interval — an errored socket meant an uncaught exception.
- `probe()` could throw synchronously from `send()` on a closed socket, leaking a pending-probe entry whose 5 s timeout later rejected a promise nobody held (another unhandled rejection). It now rejects the probe promise and cleans up.

This class of failure is a likely cause of `Error: ready_timeout` crash reports from users: the finder starts at module load (app boot), and in the released version a persistent socket error — e.g. the network still being down right after a Homey reboot, making the broadcast `send()` fail with `ENETUNREACH` — produced the tight error→restart loop above, starving the event loop during exactly the window in which the app must signal ready.

## 6. Static IP setting was not validated (and not trimmed)

The settings page accepted any text for `static_ip`; a typo put the device into an endless, silent connect-retry loop. The pairing flow validated the IP but `onSettings` did not.

- `isValidIpv4` moved from the driver to `utils/` and is now also used in `onSettings`; invalid input is rejected with a localized error (en/nl), so Homey shows the message and keeps the previous value.
- The validator now rejects leading-zero octets (`01.2.3.4`), which can be interpreted as octal.
- `_getStaticIpSetting()` trims whitespace — previously `' 192.168.1.5 '` passed pairing validation (which trims) but was used verbatim as the connect host.

## 7. "Skip UDP scan" pairing broke discovery and allowed duplicates

Devices added with "Skip UDP scan" used to get the IP address stored as both `data.id` and `data.mac` — the real MAC is unknown at pair time and Homey device data is immutable afterwards. Two consequences:

- Clearing the `static_ip` setting made the device **permanently unreachable**: MAC-based discovery compared broadcast MACs against an IP string and could never match.
- If the same unit later appeared in the pairing list via broadcast (real MAC as `data.id`), Homey couldn't recognize it as already paired → re-pairing created a duplicate device.

Fixed in two steps:

- The real MAC is resolved on the first successful connection (`client.getDeviceId()`) and persisted in the mutable device **store**. `getMac()` prefers the stored value and is used for discovery matching, so these devices keep working after the static IP is cleared. Existing devices migrate automatically the next time they connect. `list_devices` additionally filters broadcast/manual results against the resolved MACs of already-paired devices to prevent duplicates.
- Skip-scan devices no longer forge a MAC at all: they are created with `data = { id: <ip> }` only (the IP is still needed as the unique, immutable device id) plus the `static_ip` setting. `getMac()` returns `undefined` until the first connection and `_findDevices` explicitly skips MAC matching until then, instead of comparing against a placeholder. Devices paired with the legacy IP-as-MAC data keep working via the `data.mac` fallback and the same store migration.

Remaining limitation: a duplicate is still possible when "Skip UDP scan" is used for a unit already paired under its real MAC — with UDP blocked there is nothing to compare against at pair time.

## 8. Resources were not released on app shutdown (`onUninit`)

Nothing in the app implemented `onUninit` at any level, so on app shutdown (update/restart/uninstall) it left open handles behind — exactly what the SDK complains about with "This may indicate that your app is not cleaning up all resources in `onUninit()`" in crash reports:

- The `Finder` singleton kept its UDP socket bound to port 7000, the 30 s broadcast interval (a plain global `setInterval`, invisible to the SDK's auto-cleanup), a pending restart timer and any pending probe timeouts.
- Each device leaked its `gree-hvac-client` instance, which owns its own socket and polling timers. The existing cleanup in `onDeleted` only runs on device removal, not on app teardown.

Fixed with:

- `Finder.stop()`: clears the broadcast interval and a pending restart, rejects pending probes (so no orphaned timeout fires against a dead socket) and closes the socket.
- `Driver.onUninit()` stops the finder.
- `Device.onUninit()` reuses the `onDeleted` cleanup (extracted to `_cleanup()`): stop the discovery interval, cancel the no-response reconnect, disconnect the client.

## Known issues intentionally NOT addressed here

- **`logLevel: 'debug'`** on the HVAC client and per-packet `info` logging in the finder are noisy but useful for support; left as is.
- **Private API usage** (`_client._transformer` / `_client._properties`) is now confined to one helper (`_getCurrentClientProperties`) but still relies on library internals of the pinned fork.

## Test plan

- `npm test` (eslint + jest): 14 suites, 74 tests passing.
- New suites cover: null-client listener guards, no-response reconnect scheduling/cancellation, trigger gating, disconnect rejection handling, finder restart/broadcast/probe failure paths, IP validation (driver + settings + trimming), MAC resolution/dedup for "Skip UDP scan" devices, and resource cleanup on app shutdown (`finder.stop()`, device `onUninit`/`onDeleted`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
