### PR TITLE
Add "Power save", "Sleep" and "Fresh air" mode support

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -113,5 +113,8 @@
   },
   "0.13.0": {
     "en": "Add support of \"Health\" (Cold plasma) mode"
+  },
+  "1.0.0": {
+    "en": "Add support of \"Power save\", \"Sleep\" and \"Fresh air\" modes"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.gree",
-  "version": "0.13.0",
+  "version": "1.0.0",
   "compatibility": ">=12.0.1",
   "sdk": 3,
   "brandColor": "#ff732e",

--- a/.homeycompose/capabilities/fresh_air_mode.json
+++ b/.homeycompose/capabilities/fresh_air_mode.json
@@ -1,0 +1,50 @@
+{
+  "type": "enum",
+  "title": {
+    "en": "Fresh air mode",
+    "nl": "Verse lucht modus",
+    "de": "Frischluftmodus"
+  },
+  "desc": {
+    "en": "Fresh air valve mode of the HVAC",
+    "nl": "Verse luchtklep modus van de HVAC",
+    "de": "Frischluftventil-Modus der Klimaanlage"
+  },
+  "values": [
+    {
+      "id": "off",
+      "title": {
+        "en": "Off",
+        "nl": "Uit",
+        "de": "Aus"
+      }
+    },
+    {
+      "id": "inside",
+      "title": {
+        "en": "Inside",
+        "nl": "Binnen",
+        "de": "Innen"
+      }
+    },
+    {
+      "id": "outside",
+      "title": {
+        "en": "Outside",
+        "nl": "Buiten",
+        "de": "Außen"
+      }
+    },
+    {
+      "id": "mode3",
+      "title": {
+        "en": "Mode 3",
+        "nl": "Mode 3",
+        "de": "Mode 3"
+      }
+    }
+  ],
+  "getable": true,
+  "setable": true,
+  "uiComponent": "picker"
+}

--- a/.homeycompose/capabilities/power_save_mode.json
+++ b/.homeycompose/capabilities/power_save_mode.json
@@ -1,0 +1,16 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "Power save mode",
+    "nl": "Energiebesparende modus",
+    "de": "Energiesparmodus"
+  },
+  "desc": {
+    "en": "Power saving mode of the HVAC",
+    "nl": "Energiebesparende modus van de HVAC",
+    "de": "Energiesparmodus der Klimaanlage"
+  },
+  "getable": true,
+  "setable": true,
+  "uiComponent": "toggle"
+}

--- a/.homeycompose/capabilities/sleep_mode.json
+++ b/.homeycompose/capabilities/sleep_mode.json
@@ -1,0 +1,16 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "Sleep mode",
+    "nl": "Slaapmodus",
+    "de": "Schlafmodus"
+  },
+  "desc": {
+    "en": "Sleep mode gradually changes the temperature in Cool, Heat and Dry mode",
+    "nl": "Slaapmodus verandert geleidelijk de temperatuur in de modi Koelen, Verwarmen en Ontvochtigen",
+    "de": "Der Schlafmodus ändert die Temperatur schrittweise in den Modi Kühlen, Heizen und Trocknen"
+  },
+  "getable": true,
+  "setable": true,
+  "uiComponent": "toggle"
+}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ That means you need to turn it on manually when switch to Dry/Cool mode if you w
 ### Health mode
 "Health mode" (also known as "Cold plasma") enables the ionizer air purification feature on supported HVACs.
 
+### Power save mode
+"Power save mode" reduces the energy consumption of the HVAC.
+
+### Sleep mode
+"Sleep mode" gradually changes the temperature in Cool, Heat and Dry mode for a comfortable sleep.
+
+### Fresh air mode
+"Fresh air mode" controls the fresh air valve (ventilation) on HVACs equipped with it.
+
 ## Links
 [Gree app in Homey Apps](https://apps.athom.com/app/com.gree)
 

--- a/README.nl.txt
+++ b/README.nl.txt
@@ -36,3 +36,12 @@ Opmerkingen
 
 * Gezondheidsmodus
 ** "Gezondheidsmodus" (ook bekend als "Koud plasma") schakelt de ionisator-luchtreinigingsfunctie in op ondersteunde HVAC's.
+
+* Energiebesparende modus
+** "Energiebesparende modus" vermindert het energieverbruik van de HVAC.
+
+* Slaapmodus
+** "Slaapmodus" verandert geleidelijk de temperatuur in de modi Koelen, Verwarmen en Ontvochtigen voor een comfortabele slaap.
+
+* Verse lucht modus
+** "Verse lucht modus" bedient de verse luchtklep (ventilatie) op HVAC's die hiermee zijn uitgerust.

--- a/README.txt
+++ b/README.txt
@@ -35,3 +35,12 @@ Notes
 
 * Health mode
 ** "Health mode" (also known as "Cold plasma") enables the ionizer air purification feature on supported HVACs.
+
+* Power save mode
+** "Power save mode" reduces the energy consumption of the HVAC.
+
+* Sleep mode
+** "Sleep mode" gradually changes the temperature in Cool, Heat and Dry mode for a comfortable sleep.
+
+* Fresh air mode
+** "Fresh air mode" controls the fresh air valve (ventilation) on HVACs equipped with it.

--- a/app.js
+++ b/app.js
@@ -87,6 +87,27 @@ class GreeHVAC extends Homey.App {
                 return onoffToBoolean(args.mode) === healthMode;
             });
 
+        this.homey.flow.getConditionCard('power_save_mode_is')
+            .registerRunListener((args, state) => {
+                const powerSaveMode = args.device.getCapabilityValue('power_save_mode');
+                args.device.log('[condition]', '[current power save mode]', powerSaveMode);
+                return onoffToBoolean(args.mode) === powerSaveMode;
+            });
+
+        this.homey.flow.getConditionCard('sleep_mode_is')
+            .registerRunListener((args, state) => {
+                const sleepMode = args.device.getCapabilityValue('sleep_mode');
+                args.device.log('[condition]', '[current sleep mode]', sleepMode);
+                return onoffToBoolean(args.mode) === sleepMode;
+            });
+
+        this.homey.flow.getConditionCard('fresh_air_mode_is')
+            .registerRunListener((args, state) => {
+                const freshAirMode = args.device.getCapabilityValue('fresh_air_mode');
+                args.device.log('[condition]', '[current fresh air mode]', freshAirMode);
+                return args.mode === freshAirMode;
+            });
+
         // Register actions for flows
         this.homey.flow.getActionCard('set_hvac_mode')
             .registerRunListener((args, state) => {
@@ -164,6 +185,30 @@ class GreeHVAC extends Homey.App {
                 return args.device.setCapabilityValue('health_mode', onoffToBoolean(args.mode))
                     .then(() => {
                         return args.device.triggerCapabilityListener('health_mode', onoffToBoolean(args.mode), {});
+                    });
+            });
+
+        this.homey.flow.getActionCard('set_power_save_mode')
+            .registerRunListener((args, state) => {
+                return args.device.setCapabilityValue('power_save_mode', onoffToBoolean(args.mode))
+                    .then(() => {
+                        return args.device.triggerCapabilityListener('power_save_mode', onoffToBoolean(args.mode), {});
+                    });
+            });
+
+        this.homey.flow.getActionCard('set_sleep_mode')
+            .registerRunListener((args, state) => {
+                return args.device.setCapabilityValue('sleep_mode', onoffToBoolean(args.mode))
+                    .then(() => {
+                        return args.device.triggerCapabilityListener('sleep_mode', onoffToBoolean(args.mode), {});
+                    });
+            });
+
+        this.homey.flow.getActionCard('set_fresh_air_mode')
+            .registerRunListener((args, state) => {
+                return args.device.setCapabilityValue('fresh_air_mode', args.mode)
+                    .then(() => {
+                        return args.device.triggerCapabilityListener('fresh_air_mode', args.mode, {});
                     });
             });
     }

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.gree",
-  "version": "0.13.0",
+  "version": "1.0.0",
   "compatibility": ">=12.0.1",
   "sdk": 3,
   "brandColor": "#ff732e",
@@ -334,6 +334,87 @@
               "de": "Gesundheitsmodus"
             },
             "example": "true"
+          }
+        ]
+      },
+      {
+        "id": "power_save_mode_changed",
+        "title": {
+          "en": "Power save mode changed",
+          "nl": "Energiebesparende modus veranderd",
+          "de": "Energiesparmodus geändert"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=gree_cooper_hunter_hvac"
+          }
+        ],
+        "tokens": [
+          {
+            "name": "power_save_mode",
+            "type": "boolean",
+            "title": {
+              "en": "Power save mode",
+              "nl": "Energiebesparende modus",
+              "de": "Energiesparmodus"
+            },
+            "example": "true"
+          }
+        ]
+      },
+      {
+        "id": "sleep_mode_changed",
+        "title": {
+          "en": "Sleep mode changed",
+          "nl": "Slaapmodus veranderd",
+          "de": "Schlafmodus geändert"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=gree_cooper_hunter_hvac"
+          }
+        ],
+        "tokens": [
+          {
+            "name": "sleep_mode",
+            "type": "boolean",
+            "title": {
+              "en": "Sleep mode",
+              "nl": "Slaapmodus",
+              "de": "Schlafmodus"
+            },
+            "example": "true"
+          }
+        ]
+      },
+      {
+        "id": "fresh_air_mode_changed",
+        "title": {
+          "en": "Fresh air mode changed",
+          "nl": "Verse lucht modus veranderd",
+          "de": "Frischluftmodus geändert"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=gree_cooper_hunter_hvac"
+          }
+        ],
+        "tokens": [
+          {
+            "name": "fresh_air_mode",
+            "type": "string",
+            "title": {
+              "en": "Fresh air mode",
+              "nl": "Verse lucht modus",
+              "de": "Frischluftmodus"
+            },
+            "example": "off"
           }
         ]
       }
@@ -906,6 +987,136 @@
                   "en": "Off",
                   "nl": "Uit",
                   "de": "Ausschalten"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "power_save_mode_is",
+        "title": {
+          "en": "Power save mode !{{is|isn't}} ..."
+        },
+        "titleFormatted": {
+          "en": "Power save mode !{{is|isn't}} [[mode]]"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=gree_cooper_hunter_hvac"
+          },
+          {
+            "name": "mode",
+            "type": "dropdown",
+            "values": [
+              {
+                "id": "on",
+                "label": {
+                  "en": "On",
+                  "nl": "Aan",
+                  "de": "Einschalten"
+                }
+              },
+              {
+                "id": "off",
+                "label": {
+                  "en": "Off",
+                  "nl": "Uit",
+                  "de": "Ausschalten"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "sleep_mode_is",
+        "title": {
+          "en": "Sleep mode !{{is|isn't}} ..."
+        },
+        "titleFormatted": {
+          "en": "Sleep mode !{{is|isn't}} [[mode]]"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=gree_cooper_hunter_hvac"
+          },
+          {
+            "name": "mode",
+            "type": "dropdown",
+            "values": [
+              {
+                "id": "on",
+                "label": {
+                  "en": "On",
+                  "nl": "Aan",
+                  "de": "Einschalten"
+                }
+              },
+              {
+                "id": "off",
+                "label": {
+                  "en": "Off",
+                  "nl": "Uit",
+                  "de": "Ausschalten"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "fresh_air_mode_is",
+        "title": {
+          "en": "Fresh air mode !{{is|isn't}} ..."
+        },
+        "titleFormatted": {
+          "en": "Fresh air mode !{{is|isn't}} [[mode]]"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=gree_cooper_hunter_hvac"
+          },
+          {
+            "name": "mode",
+            "type": "dropdown",
+            "values": [
+              {
+                "id": "off",
+                "title": {
+                  "en": "Off",
+                  "nl": "Uit",
+                  "de": "Aus"
+                }
+              },
+              {
+                "id": "inside",
+                "title": {
+                  "en": "Inside",
+                  "nl": "Binnen",
+                  "de": "Innen"
+                }
+              },
+              {
+                "id": "outside",
+                "title": {
+                  "en": "Outside",
+                  "nl": "Buiten",
+                  "de": "Außen"
+                }
+              },
+              {
+                "id": "mode3",
+                "title": {
+                  "en": "Mode 3",
+                  "nl": "Mode 3",
+                  "de": "Mode 3"
                 }
               }
             ]
@@ -1486,6 +1697,148 @@
         ]
       },
       {
+        "id": "set_power_save_mode",
+        "title": {
+          "en": "Set power save mode",
+          "nl": "Stel de energiebesparende modus in",
+          "de": "Stellen Sie den Energiesparmodus ein"
+        },
+        "titleFormatted": {
+          "en": "Set power save mode to [[mode]]",
+          "nl": "Stel de energiebesparende modus in op [[mode]]",
+          "de": "Stellen Sie den Energiesparmodus auf [[mode]] ein"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=gree_cooper_hunter_hvac"
+          },
+          {
+            "name": "mode",
+            "type": "dropdown",
+            "values": [
+              {
+                "id": "on",
+                "label": {
+                  "en": "On",
+                  "nl": "Aan",
+                  "de": "Einschalten"
+                }
+              },
+              {
+                "id": "off",
+                "label": {
+                  "en": "Off",
+                  "nl": "Uit",
+                  "de": "Ausschalten"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "set_sleep_mode",
+        "title": {
+          "en": "Set sleep mode",
+          "nl": "Stel de slaapmodus in",
+          "de": "Stellen Sie den Schlafmodus ein"
+        },
+        "titleFormatted": {
+          "en": "Set sleep mode to [[mode]]",
+          "nl": "Stel de slaapmodus in op [[mode]]",
+          "de": "Stellen Sie den Schlafmodus auf [[mode]] ein"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=gree_cooper_hunter_hvac"
+          },
+          {
+            "name": "mode",
+            "type": "dropdown",
+            "values": [
+              {
+                "id": "on",
+                "label": {
+                  "en": "On",
+                  "nl": "Aan",
+                  "de": "Einschalten"
+                }
+              },
+              {
+                "id": "off",
+                "label": {
+                  "en": "Off",
+                  "nl": "Uit",
+                  "de": "Ausschalten"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "set_fresh_air_mode",
+        "title": {
+          "en": "Set fresh air mode",
+          "nl": "Stel de verse lucht modus in",
+          "de": "Stellen Sie den Frischluftmodus ein"
+        },
+        "titleFormatted": {
+          "en": "Set fresh air mode to [[mode]]",
+          "nl": "Stel de verse lucht modus in op [[mode]]",
+          "de": "Stellen Sie den Frischluftmodus auf [[mode]] ein"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=gree_cooper_hunter_hvac"
+          },
+          {
+            "name": "mode",
+            "type": "dropdown",
+            "values": [
+              {
+                "id": "off",
+                "title": {
+                  "en": "Off",
+                  "nl": "Uit",
+                  "de": "Aus"
+                }
+              },
+              {
+                "id": "inside",
+                "title": {
+                  "en": "Inside",
+                  "nl": "Binnen",
+                  "de": "Innen"
+                }
+              },
+              {
+                "id": "outside",
+                "title": {
+                  "en": "Outside",
+                  "nl": "Buiten",
+                  "de": "Außen"
+                }
+              },
+              {
+                "id": "mode3",
+                "title": {
+                  "en": "Mode 3",
+                  "nl": "Mode 3",
+                  "de": "Mode 3"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
         "id": "set_health_mode",
         "title": {
           "en": "Set health mode",
@@ -1548,7 +1901,10 @@
         "vertical_swing",
         "horizontal_swing",
         "quiet_mode",
-        "health_mode"
+        "health_mode",
+        "power_save_mode",
+        "sleep_mode",
+        "fresh_air_mode"
       ],
       "capabilitiesOptions": {
         "target_temperature": {
@@ -1729,6 +2085,56 @@
       "setable": true,
       "uiComponent": "picker"
     },
+    "fresh_air_mode": {
+      "type": "enum",
+      "title": {
+        "en": "Fresh air mode",
+        "nl": "Verse lucht modus",
+        "de": "Frischluftmodus"
+      },
+      "desc": {
+        "en": "Fresh air valve mode of the HVAC",
+        "nl": "Verse luchtklep modus van de HVAC",
+        "de": "Frischluftventil-Modus der Klimaanlage"
+      },
+      "values": [
+        {
+          "id": "off",
+          "title": {
+            "en": "Off",
+            "nl": "Uit",
+            "de": "Aus"
+          }
+        },
+        {
+          "id": "inside",
+          "title": {
+            "en": "Inside",
+            "nl": "Binnen",
+            "de": "Innen"
+          }
+        },
+        {
+          "id": "outside",
+          "title": {
+            "en": "Outside",
+            "nl": "Buiten",
+            "de": "Außen"
+          }
+        },
+        {
+          "id": "mode3",
+          "title": {
+            "en": "Mode 3",
+            "nl": "Mode 3",
+            "de": "Mode 3"
+          }
+        }
+      ],
+      "getable": true,
+      "setable": true,
+      "uiComponent": "picker"
+    },
     "health_mode": {
       "type": "boolean",
       "title": {
@@ -1843,6 +2249,22 @@
       "setable": true,
       "uiComponent": "toggle"
     },
+    "power_save_mode": {
+      "type": "boolean",
+      "title": {
+        "en": "Power save mode",
+        "nl": "Energiebesparende modus",
+        "de": "Energiesparmodus"
+      },
+      "desc": {
+        "en": "Power saving mode of the HVAC",
+        "nl": "Energiebesparende modus van de HVAC",
+        "de": "Energiesparmodus der Klimaanlage"
+      },
+      "getable": true,
+      "setable": true,
+      "uiComponent": "toggle"
+    },
     "quiet_mode": {
       "type": "enum",
       "title": {
@@ -1904,6 +2326,22 @@
         "en": "The air conditioner keeps the room temperature at 8°C to prevent freezing",
         "nl": "De airconditioner houdt de kamertemperatuur op 8°C om bevriezing te voorkomen.",
         "de": "Die Klimaanlage hält die Raumtemperatur auf 8°C, um ein Einfrieren zu verhindern."
+      },
+      "getable": true,
+      "setable": true,
+      "uiComponent": "toggle"
+    },
+    "sleep_mode": {
+      "type": "boolean",
+      "title": {
+        "en": "Sleep mode",
+        "nl": "Slaapmodus",
+        "de": "Schlafmodus"
+      },
+      "desc": {
+        "en": "Sleep mode gradually changes the temperature in Cool, Heat and Dry mode",
+        "nl": "Slaapmodus verandert geleidelijk de temperatuur in de modi Koelen, Verwarmen en Ontvochtigen",
+        "de": "Der Schlafmodus ändert die Temperatur schrittweise in den Modi Kühlen, Heizen und Trocknen"
       },
       "getable": true,
       "setable": true,

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -68,6 +68,9 @@ class GreeHVACDevice extends Homey.Device {
         this._flowTriggerHorizontalSwingChanged = this.homey.flow.getDeviceTriggerCard('horizontal_swing_changed');
         this._flowTriggerQuietModeChanged = this.homey.flow.getDeviceTriggerCard('quiet_mode_changed');
         this._flowTriggerHealthModeChanged = this.homey.flow.getDeviceTriggerCard('health_mode_changed');
+        this._flowTriggerPowerSaveModeChanged = this.homey.flow.getDeviceTriggerCard('power_save_mode_changed');
+        this._flowTriggerSleepModeChanged = this.homey.flow.getDeviceTriggerCard('sleep_mode_changed');
+        this._flowTriggerFreshAirModeChanged = this.homey.flow.getDeviceTriggerCard('fresh_air_mode_changed');
 
         await this._executeCapabilityMigrations();
         await this._executeDeviceClassMigration();
@@ -365,6 +368,39 @@ class GreeHVACDevice extends Homey.Device {
 
             return Promise.resolve();
         });
+
+        this.registerCapabilityListener('power_save_mode', (value) => {
+            const rawValue = value ? HVAC.VALUE.powerSave.on : HVAC.VALUE.powerSave.off;
+            this.log('[power save mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
+            if (this._setClientProperty(HVAC.PROPERTY.powerSave, rawValue)) {
+                this._flowTriggerPowerSaveModeChanged.trigger(this, { power_save_mode: value });
+            }
+
+            return Promise.resolve();
+        });
+
+        this.registerCapabilityListener('sleep_mode', (value) => {
+            const rawValue = value ? HVAC.VALUE.sleep.on : HVAC.VALUE.sleep.off;
+            this.log('[sleep mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
+            if (this._setClientProperty(HVAC.PROPERTY.sleep, rawValue)) {
+                this._flowTriggerSleepModeChanged.trigger(this, { sleep_mode: value });
+            }
+
+            return Promise.resolve();
+        });
+
+        this.registerCapabilityListener('fresh_air_mode', (value) => {
+            const rawValue = HVAC.VALUE.air[value];
+            if (rawValue === undefined) {
+                return Promise.reject(new Error(`Unknown fresh air mode value: ${JSON.stringify(value)}`));
+            }
+            this.log('[fresh air mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
+            if (this._setClientProperty(HVAC.PROPERTY.air, rawValue)) {
+                this._flowTriggerFreshAirModeChanged.trigger(this, { fresh_air_mode: value });
+            }
+
+            return Promise.resolve();
+        });
     }
 
     /**
@@ -554,6 +590,30 @@ class GreeHVACDevice extends Homey.Device {
             this.setCapabilityValue('health_mode', value).then(() => {
                 this.log('[update properties]', '[health_mode]', value);
                 return this._flowTriggerHealthModeChanged.trigger(this, { health_mode: value });
+            }).catch(this.error);
+        }
+
+        if (this._checkBoolPropertyChanged(updatedProperties, HVAC.PROPERTY.powerSave, 'power_save_mode')) {
+            const value = updatedProperties[HVAC.PROPERTY.powerSave] === HVAC.VALUE.powerSave.on;
+            this.setCapabilityValue('power_save_mode', value).then(() => {
+                this.log('[update properties]', '[power_save_mode]', value);
+                return this._flowTriggerPowerSaveModeChanged.trigger(this, { power_save_mode: value });
+            }).catch(this.error);
+        }
+
+        if (this._checkBoolPropertyChanged(updatedProperties, HVAC.PROPERTY.sleep, 'sleep_mode')) {
+            const value = updatedProperties[HVAC.PROPERTY.sleep] === HVAC.VALUE.sleep.on;
+            this.setCapabilityValue('sleep_mode', value).then(() => {
+                this.log('[update properties]', '[sleep_mode]', value);
+                return this._flowTriggerSleepModeChanged.trigger(this, { sleep_mode: value });
+            }).catch(this.error);
+        }
+
+        if (this._checkPropertyChanged(updatedProperties, HVAC.PROPERTY.air, 'fresh_air_mode')) {
+            const value = updatedProperties[HVAC.PROPERTY.air];
+            this.setCapabilityValue('fresh_air_mode', value).then(() => {
+                this.log('[update properties]', '[fresh_air_mode]', value);
+                return this._flowTriggerFreshAirModeChanged.trigger(this, { fresh_air_mode: value });
             }).catch(this.error);
         }
     }
@@ -833,6 +893,22 @@ class GreeHVACDevice extends Homey.Device {
         if (!this.hasCapability('health_mode')) {
             this.log('[migration v0.13.0]', 'Adding "health_mode" capability');
             await this.addCapability('health_mode');
+        }
+
+        // Added in v1.0.0
+        if (!this.hasCapability('power_save_mode')) {
+            this.log('[migration v1.0.0]', 'Adding "power_save_mode" capability');
+            await this.addCapability('power_save_mode');
+        }
+
+        if (!this.hasCapability('sleep_mode')) {
+            this.log('[migration v1.0.0]', 'Adding "sleep_mode" capability');
+            await this.addCapability('sleep_mode');
+        }
+
+        if (!this.hasCapability('fresh_air_mode')) {
+            this.log('[migration v1.0.0]', 'Adding "fresh_air_mode" capability');
+            await this.addCapability('fresh_air_mode');
         }
     }
 

--- a/drivers/gree_cooper_hunter_hvac/driver.compose.json
+++ b/drivers/gree_cooper_hunter_hvac/driver.compose.json
@@ -16,7 +16,10 @@
     "vertical_swing",
     "horizontal_swing",
     "quiet_mode",
-    "health_mode"
+    "health_mode",
+    "power_save_mode",
+    "sleep_mode",
+    "fresh_air_mode"
   ],
   "capabilitiesOptions": {
     "target_temperature": {

--- a/drivers/gree_cooper_hunter_hvac/driver.flow.compose.json
+++ b/drivers/gree_cooper_hunter_hvac/driver.flow.compose.json
@@ -194,6 +194,69 @@
           "example": "true"
         }
       ]
+    },
+    {
+      "id": "power_save_mode_changed",
+      "title": {
+        "en": "Power save mode changed",
+        "nl": "Energiebesparende modus veranderd",
+        "de": "Energiesparmodus geändert"
+      },
+      "args": [],
+      "tokens": [
+        {
+          "name": "power_save_mode",
+          "type": "boolean",
+          "title": {
+            "en": "Power save mode",
+            "nl": "Energiebesparende modus",
+            "de": "Energiesparmodus"
+          },
+          "example": "true"
+        }
+      ]
+    },
+    {
+      "id": "sleep_mode_changed",
+      "title": {
+        "en": "Sleep mode changed",
+        "nl": "Slaapmodus veranderd",
+        "de": "Schlafmodus geändert"
+      },
+      "args": [],
+      "tokens": [
+        {
+          "name": "sleep_mode",
+          "type": "boolean",
+          "title": {
+            "en": "Sleep mode",
+            "nl": "Slaapmodus",
+            "de": "Schlafmodus"
+          },
+          "example": "true"
+        }
+      ]
+    },
+    {
+      "id": "fresh_air_mode_changed",
+      "title": {
+        "en": "Fresh air mode changed",
+        "nl": "Verse lucht modus veranderd",
+        "de": "Frischluftmodus geändert"
+      },
+      "args": [],
+      "tokens": [
+        {
+          "name": "fresh_air_mode",
+          "type": "string",
+          "title": {
+            "en": "Fresh air mode",
+            "nl": "Verse lucht modus",
+            "de": "Frischluftmodus"
+          },
+          "example": "off"
+        }
+      ]
     }
   ],
   "conditions": [
@@ -719,6 +782,121 @@
           ]
         }
       ]
+    },
+    {
+      "id": "power_save_mode_is",
+      "title": {
+        "en": "Power save mode !{{is|isn't}} ..."
+      },
+      "titleFormatted": {
+        "en": "Power save mode !{{is|isn't}} [[mode]]"
+      },
+      "args": [
+        {
+          "name": "mode",
+          "type": "dropdown",
+          "values": [
+            {
+              "id": "on",
+              "label": {
+                "en": "On",
+                "nl": "Aan",
+                "de": "Einschalten"
+              }
+            },
+            {
+              "id": "off",
+              "label": {
+                "en": "Off",
+                "nl": "Uit",
+                "de": "Ausschalten"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sleep_mode_is",
+      "title": {
+        "en": "Sleep mode !{{is|isn't}} ..."
+      },
+      "titleFormatted": {
+        "en": "Sleep mode !{{is|isn't}} [[mode]]"
+      },
+      "args": [
+        {
+          "name": "mode",
+          "type": "dropdown",
+          "values": [
+            {
+              "id": "on",
+              "label": {
+                "en": "On",
+                "nl": "Aan",
+                "de": "Einschalten"
+              }
+            },
+            {
+              "id": "off",
+              "label": {
+                "en": "Off",
+                "nl": "Uit",
+                "de": "Ausschalten"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "fresh_air_mode_is",
+      "title": {
+        "en": "Fresh air mode !{{is|isn't}} ..."
+      },
+      "titleFormatted": {
+        "en": "Fresh air mode !{{is|isn't}} [[mode]]"
+      },
+      "args": [
+        {
+          "name": "mode",
+          "type": "dropdown",
+          "values": [
+            {
+              "id": "off",
+              "title": {
+                "en": "Off",
+                "nl": "Uit",
+                "de": "Aus"
+              }
+            },
+            {
+              "id": "inside",
+              "title": {
+                "en": "Inside",
+                "nl": "Binnen",
+                "de": "Innen"
+              }
+            },
+            {
+              "id": "outside",
+              "title": {
+                "en": "Outside",
+                "nl": "Buiten",
+                "de": "Außen"
+              }
+            },
+            {
+              "id": "mode3",
+              "title": {
+                "en": "Mode 3",
+                "nl": "Mode 3",
+                "de": "Mode 3"
+              }
+            }
+          ]
+        }
+      ]
     }
   ],
   "actions": [
@@ -1234,6 +1412,133 @@
                 "en": "Mode 2",
                 "nl": "Mode 2",
                 "de": "Mode 2"
+              }
+            },
+            {
+              "id": "mode3",
+              "title": {
+                "en": "Mode 3",
+                "nl": "Mode 3",
+                "de": "Mode 3"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "set_power_save_mode",
+      "title": {
+        "en": "Set power save mode",
+        "nl": "Stel de energiebesparende modus in",
+        "de": "Stellen Sie den Energiesparmodus ein"
+      },
+      "titleFormatted": {
+        "en": "Set power save mode to [[mode]]",
+        "nl": "Stel de energiebesparende modus in op [[mode]]",
+        "de": "Stellen Sie den Energiesparmodus auf [[mode]] ein"
+      },
+      "args": [
+        {
+          "name": "mode",
+          "type": "dropdown",
+          "values": [
+            {
+              "id": "on",
+              "label": {
+                "en": "On",
+                "nl": "Aan",
+                "de": "Einschalten"
+              }
+            },
+            {
+              "id": "off",
+              "label": {
+                "en": "Off",
+                "nl": "Uit",
+                "de": "Ausschalten"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "set_sleep_mode",
+      "title": {
+        "en": "Set sleep mode",
+        "nl": "Stel de slaapmodus in",
+        "de": "Stellen Sie den Schlafmodus ein"
+      },
+      "titleFormatted": {
+        "en": "Set sleep mode to [[mode]]",
+        "nl": "Stel de slaapmodus in op [[mode]]",
+        "de": "Stellen Sie den Schlafmodus auf [[mode]] ein"
+      },
+      "args": [
+        {
+          "name": "mode",
+          "type": "dropdown",
+          "values": [
+            {
+              "id": "on",
+              "label": {
+                "en": "On",
+                "nl": "Aan",
+                "de": "Einschalten"
+              }
+            },
+            {
+              "id": "off",
+              "label": {
+                "en": "Off",
+                "nl": "Uit",
+                "de": "Ausschalten"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "set_fresh_air_mode",
+      "title": {
+        "en": "Set fresh air mode",
+        "nl": "Stel de verse lucht modus in",
+        "de": "Stellen Sie den Frischluftmodus ein"
+      },
+      "titleFormatted": {
+        "en": "Set fresh air mode to [[mode]]",
+        "nl": "Stel de verse lucht modus in op [[mode]]",
+        "de": "Stellen Sie den Frischluftmodus auf [[mode]] ein"
+      },
+      "args": [
+        {
+          "name": "mode",
+          "type": "dropdown",
+          "values": [
+            {
+              "id": "off",
+              "title": {
+                "en": "Off",
+                "nl": "Uit",
+                "de": "Aus"
+              }
+            },
+            {
+              "id": "inside",
+              "title": {
+                "en": "Inside",
+                "nl": "Binnen",
+                "de": "Innen"
+              }
+            },
+            {
+              "id": "outside",
+              "title": {
+                "en": "Outside",
+                "nl": "Buiten",
+                "de": "Außen"
               }
             },
             {

--- a/test/device.freshAirMode.test.js
+++ b/test/device.freshAirMode.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+describe('GreeHVACDevice fresh_air_mode listener', () => {
+    let GreeHVACDevice;
+    let device;
+    let capabilityListeners;
+
+    beforeEach(() => {
+        jest.resetModules();
+
+        capabilityListeners = {};
+
+        jest.doMock('../drivers/gree_cooper_hunter_hvac/network/finder', () => ({ hvacs: [] }));
+
+        jest.doMock('gree-hvac-client', () => ({
+            PROPERTY: { air: 'air' },
+            VALUE: {
+                air: {
+                    off: 'off',
+                    inside: 'inside',
+                    outside: 'outside',
+                    mode3: 'mode3',
+                },
+            },
+        }));
+
+        jest.doMock('homey', () => ({
+            Device: class Device {
+                log() {}
+                error() {}
+            },
+        }));
+
+        GreeHVACDevice = require('../drivers/gree_cooper_hunter_hvac/device');
+
+        device = new GreeHVACDevice();
+        device.registerCapabilityListener = jest.fn((capability, listener) => {
+            capabilityListeners[capability] = listener;
+        });
+        device._setClientProperty = jest.fn().mockReturnValue(true);
+        device._flowTriggerFreshAirModeChanged = {
+            trigger: jest.fn(),
+        };
+        device.log = jest.fn();
+    });
+
+    test('sets fresh air mode to outside', async () => {
+        device._registerCapabilityListeners();
+
+        await capabilityListeners.fresh_air_mode('outside');
+
+        expect(device._setClientProperty).toHaveBeenCalledWith('air', 'outside');
+        expect(device._flowTriggerFreshAirModeChanged.trigger).toHaveBeenCalledWith(device, { fresh_air_mode: 'outside' });
+    });
+
+    test('turns fresh air mode off', async () => {
+        device._registerCapabilityListeners();
+
+        await capabilityListeners.fresh_air_mode('off');
+
+        expect(device._setClientProperty).toHaveBeenCalledWith('air', 'off');
+        expect(device._flowTriggerFreshAirModeChanged.trigger).toHaveBeenCalledWith(device, { fresh_air_mode: 'off' });
+    });
+
+    test('rejects unknown fresh air mode values', async () => {
+        device._registerCapabilityListeners();
+
+        await expect(capabilityListeners.fresh_air_mode(null))
+            .rejects.toThrow('Unknown fresh air mode value: null');
+
+        expect(device._setClientProperty).not.toHaveBeenCalled();
+        expect(device._flowTriggerFreshAirModeChanged.trigger).not.toHaveBeenCalled();
+    });
+});

--- a/test/device.powerSaveMode.test.js
+++ b/test/device.powerSaveMode.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+describe('GreeHVACDevice power_save_mode listener', () => {
+    let GreeHVACDevice;
+    let device;
+    let capabilityListeners;
+
+    beforeEach(() => {
+        jest.resetModules();
+
+        capabilityListeners = {};
+
+        jest.doMock('../drivers/gree_cooper_hunter_hvac/network/finder', () => ({ hvacs: [] }));
+
+        jest.doMock('gree-hvac-client', () => ({
+            PROPERTY: { powerSave: 'powerSave' },
+            VALUE: {
+                powerSave: {
+                    off: 'off',
+                    on: 'on',
+                },
+            },
+        }));
+
+        jest.doMock('homey', () => ({
+            Device: class Device {
+                log() {}
+                error() {}
+            },
+        }));
+
+        GreeHVACDevice = require('../drivers/gree_cooper_hunter_hvac/device');
+
+        device = new GreeHVACDevice();
+        device.registerCapabilityListener = jest.fn((capability, listener) => {
+            capabilityListeners[capability] = listener;
+        });
+        device._setClientProperty = jest.fn().mockReturnValue(true);
+        device._flowTriggerPowerSaveModeChanged = {
+            trigger: jest.fn(),
+        };
+        device.log = jest.fn();
+    });
+
+    test('turns power save mode on', async () => {
+        device._registerCapabilityListeners();
+
+        await capabilityListeners.power_save_mode(true);
+
+        expect(device._setClientProperty).toHaveBeenCalledWith('powerSave', 'on');
+        expect(device._flowTriggerPowerSaveModeChanged.trigger).toHaveBeenCalledWith(device, { power_save_mode: true });
+    });
+
+    test('turns power save mode off', async () => {
+        device._registerCapabilityListeners();
+
+        await capabilityListeners.power_save_mode(false);
+
+        expect(device._setClientProperty).toHaveBeenCalledWith('powerSave', 'off');
+        expect(device._flowTriggerPowerSaveModeChanged.trigger).toHaveBeenCalledWith(device, { power_save_mode: false });
+    });
+
+    test('does not trigger the flow when the client is not connected', async () => {
+        device._setClientProperty.mockReturnValue(false);
+        device._registerCapabilityListeners();
+
+        await capabilityListeners.power_save_mode(true);
+
+        expect(device._flowTriggerPowerSaveModeChanged.trigger).not.toHaveBeenCalled();
+    });
+});

--- a/test/device.sleepMode.test.js
+++ b/test/device.sleepMode.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+describe('GreeHVACDevice sleep_mode listener', () => {
+    let GreeHVACDevice;
+    let device;
+    let capabilityListeners;
+
+    beforeEach(() => {
+        jest.resetModules();
+
+        capabilityListeners = {};
+
+        jest.doMock('../drivers/gree_cooper_hunter_hvac/network/finder', () => ({ hvacs: [] }));
+
+        jest.doMock('gree-hvac-client', () => ({
+            PROPERTY: { sleep: 'sleep' },
+            VALUE: {
+                sleep: {
+                    off: 'off',
+                    on: 'on',
+                },
+            },
+        }));
+
+        jest.doMock('homey', () => ({
+            Device: class Device {
+                log() {}
+                error() {}
+            },
+        }));
+
+        GreeHVACDevice = require('../drivers/gree_cooper_hunter_hvac/device');
+
+        device = new GreeHVACDevice();
+        device.registerCapabilityListener = jest.fn((capability, listener) => {
+            capabilityListeners[capability] = listener;
+        });
+        device._setClientProperty = jest.fn().mockReturnValue(true);
+        device._flowTriggerSleepModeChanged = {
+            trigger: jest.fn(),
+        };
+        device.log = jest.fn();
+    });
+
+    test('turns sleep mode on', async () => {
+        device._registerCapabilityListeners();
+
+        await capabilityListeners.sleep_mode(true);
+
+        expect(device._setClientProperty).toHaveBeenCalledWith('sleep', 'on');
+        expect(device._flowTriggerSleepModeChanged.trigger).toHaveBeenCalledWith(device, { sleep_mode: true });
+    });
+
+    test('turns sleep mode off', async () => {
+        device._registerCapabilityListeners();
+
+        await capabilityListeners.sleep_mode(false);
+
+        expect(device._setClientProperty).toHaveBeenCalledWith('sleep', 'off');
+        expect(device._flowTriggerSleepModeChanged.trigger).toHaveBeenCalledWith(device, { sleep_mode: false });
+    });
+
+    test('does not trigger the flow when the client is not connected', async () => {
+        device._setClientProperty.mockReturnValue(false);
+        device._registerCapabilityListeners();
+
+        await capabilityListeners.sleep_mode(true);
+
+        expect(device._flowTriggerSleepModeChanged.trigger).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Implements three long-standing capability requests as v1.0.0, following the pattern established by the "Health" (Cold plasma) mode (#249).

Closes #6
Closes #10
Closes #11

## New capabilities

| Capability | Type | HVAC property | Issue |
|---|---|---|---|
| `power_save_mode` | boolean toggle | `powerSave` (`SvSt`) | #6 |
| `sleep_mode` | boolean toggle | `sleep` (`SwhSlp`/`SlpMod`) | #11 |
| `fresh_air_mode` | enum: off / inside / outside / mode3 | `air` (`Air`) | #10 |

The bundled gree-hvac-client already writes the `SwhSlp`/`SlpMod` vendor-code pair in lockstep, so sleep mode needs no extra handling in the app.

## Changes per capability

- Capability definition in `.homeycompose/capabilities/` with en/nl/de translations, added to the driver capability list
- Flow cards: `*_changed` trigger (with token), `*_is` condition, `set_*` action, with run listeners registered in `app.js`
- `device.js`: capability listener sending the value to the HVAC and firing the flow trigger only when the command was actually sent (guarded turbo/quiet pattern), `_onUpdate` sync of polled HVAC state back into Homey, and a v1.0.0 migration adding the capabilities to already-paired devices
- `fresh_air_mode` rejects unknown values the same way the quiet mode listener does
- Listener tests per mode (on/off/enum values, not-connected and unknown-value cases)
- README notes (en/nl), version bump to 1.0.0 with changelog entry, `app.json` regenerated via `homey app build`

## Testing

- `npm test`: eslint clean, 86 tests in 18 suites pass
- `homey app build` validates successfully against level `debug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)