### PR TITLE
Add configurable minimum target temperature (#182)

### DIFF
--- a/app.json
+++ b/app.json
@@ -3637,6 +3637,61 @@
               "value": ""
             }
           ]
+        },
+        {
+          "type": "group",
+          "label": {
+            "en": "Temperature",
+            "nl": "Temperatuur",
+            "de": "Temperatur",
+            "fr": "Température",
+            "it": "Temperatura",
+            "sv": "Temperatur",
+            "no": "Temperatur",
+            "es": "Temperatura",
+            "da": "Temperatur",
+            "pl": "Temperatura",
+            "ko": "온도"
+          },
+          "children": [
+            {
+              "id": "min_target_temperature",
+              "type": "number",
+              "label": {
+                "en": "Minimum target temperature",
+                "nl": "Minimale doeltemperatuur",
+                "de": "Minimale Zieltemperatur",
+                "fr": "Température cible minimale",
+                "it": "Temperatura target minima",
+                "sv": "Lägsta måltemperatur",
+                "no": "Laveste måltemperatur",
+                "es": "Temperatura objetivo mínima",
+                "da": "Laveste måltemperatur",
+                "pl": "Minimalna temperatura docelowa",
+                "ko": "최저 목표 온도"
+              },
+              "hint": {
+                "en": "The lowest temperature you can set for this device. Some heat pumps support down to 8 °C.",
+                "nl": "De laagste temperatuur die je voor dit apparaat kunt instellen. Sommige warmtepompen ondersteunen tot 8 °C.",
+                "de": "Die niedrigste Temperatur, die du für dieses Gerät einstellen kannst. Einige Wärmepumpen unterstützen bis zu 8 °C.",
+                "fr": "La température la plus basse que vous pouvez définir pour cet appareil. Certaines pompes à chaleur descendent jusqu'à 8 °C.",
+                "it": "La temperatura più bassa impostabile per questo dispositivo. Alcune pompe di calore arrivano fino a 8 °C.",
+                "sv": "Den lägsta temperaturen du kan ställa in för den här enheten. Vissa värmepumpar stöder ned till 8 °C.",
+                "no": "Den laveste temperaturen du kan angi for denne enheten. Noen varmepumper støtter ned til 8 °C.",
+                "es": "La temperatura más baja que puedes configurar para este dispositivo. Algunas bombas de calor admiten hasta 8 °C.",
+                "da": "Den laveste temperatur, du kan indstille for denne enhed. Nogle varmepumper understøtter ned til 8 °C.",
+                "pl": "Najniższa temperatura, jaką możesz ustawić dla tego urządzenia. Niektóre pompy ciepła obsługują nawet 8 °C.",
+                "ko": "이 기기에 설정할 수 있는 최저 온도입니다. 일부 히트펌프는 8 °C까지 지원합니다."
+              },
+              "value": 16,
+              "min": 8,
+              "max": 30,
+              "step": 1,
+              "units": {
+                "en": "°C"
+              }
+            }
+          ]
         }
       ],
       "images": {

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -21,6 +21,12 @@ const CONNECT_TIMEOUT = 5000;
 // the connection is dropped and discovery is restarted (ms)
 const NO_RESPONSE_RECONNECT_TIMEOUT = 60 * 1000;
 
+// Bounds for the target_temperature capability. The minimum is user-configurable
+// via the "min_target_temperature" device setting (some heat pumps support 8 °C).
+const TARGET_TEMPERATURE_MAX = 30;
+const TARGET_TEMPERATURE_STEP = 1;
+const DEFAULT_MIN_TARGET_TEMPERATURE = 16;
+
 class GreeHVACDevice extends Homey.Device {
 
     /**
@@ -74,6 +80,7 @@ class GreeHVACDevice extends Homey.Device {
 
         await this._executeCapabilityMigrations();
         await this._executeDeviceClassMigration();
+        await this._applyTargetTemperatureRange();
         this._registerCapabilityListeners();
 
         this._markOffline();
@@ -114,22 +121,40 @@ class GreeHVACDevice extends Homey.Device {
         this._tryToDisconnect();
     }
 
-    onSettings({ oldSettings, newSettings, changedKeys }) {
-        if (!changedKeys.includes('static_ip')) {
-            return;
+    async onSettings({ oldSettings, newSettings, changedKeys }) {
+        if (changedKeys.includes('static_ip') && oldSettings.static_ip !== newSettings.static_ip) {
+            if (newSettings.static_ip && !isValidIpv4(newSettings.static_ip)) {
+                throw new Error(this.homey.__('error.invalid_static_ip'));
+            }
+
+            this.log('[settings]', 'Static IP changed. Reconnecting.');
+            this._staticIpSetting = newSettings.static_ip;
+            this.reconnect();
         }
 
-        if (oldSettings.static_ip === newSettings.static_ip) {
-            return;
+        if (changedKeys.includes('min_target_temperature')) {
+            this.log('[settings]', 'Minimum target temperature changed:', newSettings.min_target_temperature);
+            await this._applyTargetTemperatureRange(newSettings.min_target_temperature);
         }
+    }
 
-        if (newSettings.static_ip && !isValidIpv4(newSettings.static_ip)) {
-            throw new Error(this.homey.__('error.invalid_static_ip'));
-        }
+    /**
+     * Apply the target_temperature capability range. The minimum is taken from the
+     * "min_target_temperature" device setting so users can set lower temperatures
+     * (e.g. 8 °C for frost protection). Max and step remain constant.
+     *
+     * @param {number} [min] Explicit minimum (e.g. from onSettings' newSettings);
+     *                       falls back to the persisted setting when omitted.
+     * @private
+     */
+    async _applyTargetTemperatureRange(min) {
+        const minTemperature = min ?? this.getSetting('min_target_temperature') ?? DEFAULT_MIN_TARGET_TEMPERATURE;
 
-        this.log('[settings]', 'Static IP changed. Reconnecting.');
-        this._staticIpSetting = newSettings.static_ip;
-        this.reconnect();
+        await this.setCapabilityOptions('target_temperature', {
+            min: minTemperature,
+            max: TARGET_TEMPERATURE_MAX,
+            step: TARGET_TEMPERATURE_STEP,
+        });
     }
 
     /**

--- a/drivers/gree_cooper_hunter_hvac/driver.compose.json
+++ b/drivers/gree_cooper_hunter_hvac/driver.compose.json
@@ -212,6 +212,61 @@
           "value": ""
         }
       ]
+    },
+    {
+      "type": "group",
+      "label": {
+        "en": "Temperature",
+        "nl": "Temperatuur",
+        "de": "Temperatur",
+        "fr": "Température",
+        "it": "Temperatura",
+        "sv": "Temperatur",
+        "no": "Temperatur",
+        "es": "Temperatura",
+        "da": "Temperatur",
+        "pl": "Temperatura",
+        "ko": "온도"
+      },
+      "children": [
+        {
+          "id": "min_target_temperature",
+          "type": "number",
+          "label": {
+            "en": "Minimum target temperature",
+            "nl": "Minimale doeltemperatuur",
+            "de": "Minimale Zieltemperatur",
+            "fr": "Température cible minimale",
+            "it": "Temperatura target minima",
+            "sv": "Lägsta måltemperatur",
+            "no": "Laveste måltemperatur",
+            "es": "Temperatura objetivo mínima",
+            "da": "Laveste måltemperatur",
+            "pl": "Minimalna temperatura docelowa",
+            "ko": "최저 목표 온도"
+          },
+          "hint": {
+            "en": "The lowest temperature you can set for this device. Some heat pumps support down to 8 °C.",
+            "nl": "De laagste temperatuur die je voor dit apparaat kunt instellen. Sommige warmtepompen ondersteunen tot 8 °C.",
+            "de": "Die niedrigste Temperatur, die du für dieses Gerät einstellen kannst. Einige Wärmepumpen unterstützen bis zu 8 °C.",
+            "fr": "La température la plus basse que vous pouvez définir pour cet appareil. Certaines pompes à chaleur descendent jusqu'à 8 °C.",
+            "it": "La temperatura più bassa impostabile per questo dispositivo. Alcune pompe di calore arrivano fino a 8 °C.",
+            "sv": "Den lägsta temperaturen du kan ställa in för den här enheten. Vissa värmepumpar stöder ned till 8 °C.",
+            "no": "Den laveste temperaturen du kan angi for denne enheten. Noen varmepumper støtter ned til 8 °C.",
+            "es": "La temperatura más baja que puedes configurar para este dispositivo. Algunas bombas de calor admiten hasta 8 °C.",
+            "da": "Den laveste temperatur, du kan indstille for denne enhed. Nogle varmepumper understøtter ned til 8 °C.",
+            "pl": "Najniższa temperatura, jaką możesz ustawić dla tego urządzenia. Niektóre pompy ciepła obsługują nawet 8 °C.",
+            "ko": "이 기기에 설정할 수 있는 최저 온도입니다. 일부 히트펌프는 8 °C까지 지원합니다."
+          },
+          "value": 16,
+          "min": 8,
+          "max": 30,
+          "step": 1,
+          "units": {
+            "en": "°C"
+          }
+        }
+      ]
     }
   ],
   "images": {

--- a/test/device.findDevices.test.js
+++ b/test/device.findDevices.test.js
@@ -118,18 +118,49 @@ describe('GreeHVACDevice._findDevices()', () => {
         expect(device._staticIpSetting).toBe('192.168.1.51');
     });
 
-    test('rejects an invalid static IP and does not reconnect', () => {
+    test('rejects an invalid static IP and does not reconnect', async () => {
         device.reconnect = jest.fn();
         device.homey = { __: jest.fn((key) => key) };
 
-        expect(() => device.onSettings({
+        await expect(device.onSettings({
             oldSettings: { static_ip: '' },
             newSettings: { static_ip: 'not-an-ip' },
             changedKeys: ['static_ip'],
-        })).toThrow('error.invalid_static_ip');
+        })).rejects.toThrow('error.invalid_static_ip');
 
         expect(device.reconnect).not.toHaveBeenCalled();
         expect(device._staticIpSetting).toBeUndefined();
+    });
+
+    test('applies the target temperature range when the minimum setting changes', async () => {
+        device.reconnect = jest.fn();
+        device.setCapabilityOptions = jest.fn(() => Promise.resolve());
+
+        await device.onSettings({
+            oldSettings: { min_target_temperature: 16 },
+            newSettings: { min_target_temperature: 8 },
+            changedKeys: ['min_target_temperature'],
+        });
+
+        expect(device.reconnect).not.toHaveBeenCalled();
+        expect(device.setCapabilityOptions).toHaveBeenCalledWith('target_temperature', {
+            min: 8,
+            max: 30,
+            step: 1,
+        });
+    });
+
+    test('falls back to the default minimum target temperature when the setting is unset', async () => {
+        device.getSetting = jest.fn(() => undefined);
+        device.setCapabilityOptions = jest.fn(() => Promise.resolve());
+
+        await device._applyTargetTemperatureRange();
+
+        expect(device.setCapabilityOptions).toHaveBeenCalledWith('target_temperature', {
+            min: 16,
+            max: 30,
+            step: 1,
+        });
     });
 
     test('find devices trims whitespace around the static IP setting', () => {


### PR DESCRIPTION
## Summary

Closes #182.

Gree/Cooper&Hunter heat pumps can often be set well below the current `target_temperature` floor of **16 °C** — many support **8 °C** (frost/anti-freeze protection, e.g. for a summer house). This adds a per-device setting to configure the lowest settable temperature.

## Changes

- **`driver.compose.json`** — new "Temperature" settings group with a `min_target_temperature` number field (default `16`, range `8`–`30`, `°C`), translated for all 11 locales.
- **`device.js`** — added `_applyTargetTemperatureRange()` which applies the setting to the `target_temperature` capability via `setCapabilityOptions()`. Called on `onInit()` and re-applied from `onSettings()` when the setting changes (`onSettings` is now `async`).
- **`app.json`** — regenerated via `homey app build`.
- **Tests** — updated the invalid-static-IP test for the now-async `onSettings`, and added coverage for the new range application + default fallback.

Existing devices are unaffected: the default stays 16 °C. When the setting changes, the slider minimum updates immediately without an app restart.

## Verification

- `homey app build` → app validated successfully.
- `npm test` → eslint clean, **88/88 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)