### PR TITLE
Fix English pairing copy and drop CLI/README instruction

### DIFF
--- a/locales/da.json
+++ b/locales/da.json
@@ -2,7 +2,7 @@
     "pair": {
         "intro": {
             "p1": "Før du fortsætter, skal du forbinde HVAC'en til dit nuværende WiFi-netværk.",
-            "p2": "Det kan gøres med en almindelig producentapp som <i>EWPE Smart</i> eller via CLI-instruktionen fra appens README (avancerede brugere)",
+            "p2": "Det kan gøres med en almindelig producentapp som <i>EWPE Smart</i>.",
             "static_ip_link": "Min enhed har en statisk IP-adresse →"
         },
         "static_ip": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -2,7 +2,7 @@
     "pair": {
         "intro": {
             "p1": "Bevor du fortfährst, musst du die Klimaanlage mit deinem aktuellen WLAN-Netzwerk verbinden.",
-            "p2": "Dies kann mit einer üblichen Hersteller-App wie <i>EWPE Smart</i> erfolgen oder über die CLI-Anleitung aus der README der App (für fortgeschrittene Benutzer)",
+            "p2": "Dies kann mit einer üblichen Hersteller-App wie <i>EWPE Smart</i> erfolgen.",
             "static_ip_link": "Mein Gerät hat eine statische IP-Adresse →"
         },
         "static_ip": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,8 +1,8 @@
 {
     "pair": {
         "intro": {
-            "p1": "Before continue you need to connect HVAC to your current WiFi network.",
-            "p2": "It can be done using regular manufacturer application like <i>EWPE Smart</i> or using CLI instruction from app README (advanced users)",
+            "p1": "Before continuing, you need to connect your HVAC to your current WiFi network.",
+            "p2": "This can be done using the manufacturer's app, such as <i>EWPE Smart</i>.",
             "static_ip_link": "My device has a static IP address →"
         },
         "static_ip": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -2,7 +2,7 @@
     "pair": {
         "intro": {
             "p1": "Antes de continuar, debes conectar el HVAC a tu red WiFi actual.",
-            "p2": "Se puede hacer usando una aplicación habitual del fabricante como <i>EWPE Smart</i> o mediante las instrucciones de CLI del README de la app (usuarios avanzados)",
+            "p2": "Se puede hacer usando una aplicación habitual del fabricante como <i>EWPE Smart</i>.",
             "static_ip_link": "Mi dispositivo tiene una dirección IP estática →"
         },
         "static_ip": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -2,7 +2,7 @@
     "pair": {
         "intro": {
             "p1": "Avant de continuer, tu dois connecter le HVAC à ton réseau WiFi actuel.",
-            "p2": "Cela peut se faire à l'aide d'une application classique du fabricant comme <i>EWPE Smart</i> ou en suivant les instructions CLI du README de l'application (utilisateurs avancés)",
+            "p2": "Cela peut se faire à l'aide d'une application classique du fabricant comme <i>EWPE Smart</i>.",
             "static_ip_link": "Mon appareil a une adresse IP statique →"
         },
         "static_ip": {

--- a/locales/it.json
+++ b/locales/it.json
@@ -2,7 +2,7 @@
     "pair": {
         "intro": {
             "p1": "Prima di continuare devi collegare il condizionatore alla tua attuale rete WiFi.",
-            "p2": "Puoi farlo utilizzando la normale applicazione del produttore come <i>EWPE Smart</i> o tramite le istruzioni da riga di comando presenti nel README dell'app (utenti esperti)",
+            "p2": "Puoi farlo utilizzando la normale applicazione del produttore come <i>EWPE Smart</i>.",
             "static_ip_link": "Il mio dispositivo ha un indirizzo IP statico →"
         },
         "static_ip": {

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -2,7 +2,7 @@
     "pair": {
         "intro": {
             "p1": "계속하기 전에 HVAC를 현재 WiFi 네트워크에 연결해야 합니다.",
-            "p2": "<i>EWPE Smart</i>와 같은 일반 제조사 앱을 사용하거나 앱 README의 CLI 안내를 사용하여 연결할 수 있습니다(고급 사용자)",
+            "p2": "<i>EWPE Smart</i>와 같은 일반 제조사 앱을 사용하여 연결할 수 있습니다.",
             "static_ip_link": "내 기기에 고정 IP 주소가 있습니다 →"
         },
         "static_ip": {

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -2,7 +2,7 @@
     "pair": {
         "intro": {
             "p1": "Voordat je verder gaat, moet je de Airco verbinden met je huidige WiFi-netwerk.",
-            "p2": "Dit kan je doen met behulp van een app van de fabrikant zoals <i>EWPE Smart</i> of via de CLI zoals beschreven in de README van de app (geavanceerde gebruikers)",
+            "p2": "Dit kan je doen met behulp van een app van de fabrikant zoals <i>EWPE Smart</i>.",
             "static_ip_link": "Mijn apparaat heeft een statisch IP-adres →"
         },
         "static_ip": {

--- a/locales/no.json
+++ b/locales/no.json
@@ -2,7 +2,7 @@
     "pair": {
         "intro": {
             "p1": "Før du fortsetter må du koble klimaanlegget til ditt nåværende WiFi-nettverk.",
-            "p2": "Dette kan gjøres med en vanlig produsentapp som <i>EWPE Smart</i> eller ved hjelp av CLI-instruksjonene i appens README (avanserte brukere)",
+            "p2": "Dette kan gjøres med en vanlig produsentapp som <i>EWPE Smart</i>.",
             "static_ip_link": "Enheten min har en statisk IP-adresse →"
         },
         "static_ip": {

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -2,7 +2,7 @@
     "pair": {
         "intro": {
             "p1": "Zanim przejdziesz dalej, musisz połączyć klimatyzator z bieżącą siecią WiFi.",
-            "p2": "Można to zrobić za pomocą standardowej aplikacji producenta, takiej jak <i>EWPE Smart</i>, lub za pomocą instrukcji CLI z pliku README aplikacji (użytkownicy zaawansowani)",
+            "p2": "Można to zrobić za pomocą standardowej aplikacji producenta, takiej jak <i>EWPE Smart</i>.",
             "static_ip_link": "Moje urządzenie ma statyczny adres IP →"
         },
         "static_ip": {

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -2,7 +2,7 @@
     "pair": {
         "intro": {
             "p1": "Innan du fortsätter måste du ansluta HVAC:n till ditt nuvarande WiFi-nätverk.",
-            "p2": "Det kan göras med en vanlig tillverkarapp som <i>EWPE Smart</i> eller via CLI-instruktionerna i appens README (avancerade användare)",
+            "p2": "Det kan göras med en vanlig tillverkarapp som <i>EWPE Smart</i>.",
             "static_ip_link": "Min enhet har en statisk IP-adress →"
         },
         "static_ip": {


### PR DESCRIPTION
## Summary
- Fix grammar in the English pairing intro strings (`pair.intro.p1` / `p2`) flagged in review:
  - "Before continue you need to connect HVAC..." → "Before continuing, you need to connect your HVAC..."
- Remove the "CLI instructions in the app README" option (and the now-orphaned "advanced users" qualifier) from the `p2` string across **all 11 locales** (en, da, de, es, fr, it, ko, nl, no, pl, sv).

Pairing now points users to the manufacturer's app (e.g. *EWPE Smart*) only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)