### PR TITLE
Reject capability changes when the HVAC command fails

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -531,5 +531,18 @@
     "da": "Vis en notifikation, når et Flow bruger et forældet Gree HVAC-tilstandskort, og anbefal Homeys indbyggede flowkort til termostattilstand",
     "pl": "Wyświetl powiadomienie, gdy Flow używa przestarzałej karty trybu HVAC Gree, i zalecaj wbudowane karty przepływu trybu termostatu w Homey",
     "ko": "Flow가 더 이상 사용되지 않는 Gree HVAC 모드 카드를 사용할 때 알림을 표시하고 Homey의 기본 온도 조절기 모드 플로우 카드를 권장합니다"
+  },
+  "1.1.2": {
+    "en": "Revert a control change and show a notification when the HVAC is offline, instead of silently pretending it was applied",
+    "nl": "Een bedieningswijziging terugdraaien en een melding tonen wanneer de airco offline is, in plaats van stilzwijgend te doen alsof deze is toegepast",
+    "de": "Eine Steuerungsänderung zurücksetzen und eine Benachrichtigung anzeigen, wenn die Klimaanlage offline ist, statt stillschweigend vorzugeben, sie sei übernommen worden",
+    "fr": "Annuler une modification de commande et afficher une notification lorsque le HVAC est hors ligne, au lieu de prétendre en silence qu'elle a été appliquée",
+    "it": "Annulla una modifica di controllo e mostra una notifica quando il condizionatore è offline, invece di far finta in silenzio che sia stata applicata",
+    "sv": "Ångra en kontrolländring och visa en avisering när HVAC är offline, i stället för att i tysthet låtsas att den tillämpades",
+    "no": "Angre en kontrollendring og vis et varsel når klimaanlegget er frakoblet, i stedet for stille å late som om den ble utført",
+    "es": "Revierte un cambio de control y muestra una notificación cuando el HVAC está desconectado, en lugar de fingir en silencio que se aplicó",
+    "da": "Fortryd en betjeningsændring og vis en notifikation, når HVAC er offline, i stedet for i stilhed at lade som om den blev anvendt",
+    "pl": "Cofnij zmianę sterowania i wyświetl powiadomienie, gdy klimatyzator jest offline, zamiast po cichu udawać, że została zastosowana",
+    "ko": "HVAC가 오프라인일 때 변경이 적용된 것처럼 조용히 처리하지 않고, 제어 변경을 되돌리고 알림을 표시합니다"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.gree",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "compatibility": ">=12.0.1",
   "sdk": 3,
   "brandColor": "#ff732e",

--- a/app.js
+++ b/app.js
@@ -123,104 +123,104 @@ class GreeHVAC extends Homey.App {
         this.homey.flow.getActionCard('set_hvac_mode')
             .registerRunListener((args, state) => {
                 this._notifyDeprecatedFlowCard('set_hvac_mode').catch(this.error);
-                return args.device.setCapabilityValue('thermostat_mode', args.mode)
+                return args.device.triggerCapabilityListener('thermostat_mode', args.mode, {})
                     .then(() => {
-                        return args.device.triggerCapabilityListener('thermostat_mode', args.mode, {});
+                        return args.device.setCapabilityValue('thermostat_mode', args.mode);
                     });
             });
 
         this.homey.flow.getActionCard('set_fan_speed')
             .registerRunListener((args, state) => {
-                return args.device.setCapabilityValue('fan_speed', args.speed)
+                return args.device.triggerCapabilityListener('fan_speed', args.speed, {})
                     .then(() => {
-                        return args.device.triggerCapabilityListener('fan_speed', args.speed, {});
+                        return args.device.setCapabilityValue('fan_speed', args.speed);
                     });
             });
 
         this.homey.flow.getActionCard('set_turbo_mode')
             .registerRunListener((args, state) => {
-                return args.device.setCapabilityValue('turbo_mode', onoffToBoolean(args.mode))
+                return args.device.triggerCapabilityListener('turbo_mode', onoffToBoolean(args.mode), {})
                     .then(() => {
-                        return args.device.triggerCapabilityListener('turbo_mode', onoffToBoolean(args.mode), {});
+                        return args.device.setCapabilityValue('turbo_mode', onoffToBoolean(args.mode));
                     });
             });
         this.homey.flow.getActionCard('set_safety_heating')
             .registerRunListener((args, state) => {
-                return args.device.setCapabilityValue('safety_heating', onoffToBoolean(args.mode))
+                return args.device.triggerCapabilityListener('safety_heating', onoffToBoolean(args.mode), {})
                     .then(() => {
-                        return args.device.triggerCapabilityListener('safety_heating', onoffToBoolean(args.mode), {});
+                        return args.device.setCapabilityValue('safety_heating', onoffToBoolean(args.mode));
                     });
             });
 
         this.homey.flow.getActionCard('set_lights')
             .registerRunListener((args, state) => {
-                return args.device.setCapabilityValue('lights', onoffToBoolean(args.mode))
+                return args.device.triggerCapabilityListener('lights', onoffToBoolean(args.mode), {})
                     .then(() => {
-                        return args.device.triggerCapabilityListener('lights', onoffToBoolean(args.mode), {});
+                        return args.device.setCapabilityValue('lights', onoffToBoolean(args.mode));
                     });
             });
 
         this.homey.flow.getActionCard('set_xfan_mode')
             .registerRunListener((args, state) => {
-                return args.device.setCapabilityValue('xfan_mode', onoffToBoolean(args.mode))
+                return args.device.triggerCapabilityListener('xfan_mode', onoffToBoolean(args.mode), {})
                     .then(() => {
-                        return args.device.triggerCapabilityListener('xfan_mode', onoffToBoolean(args.mode), {});
+                        return args.device.setCapabilityValue('xfan_mode', onoffToBoolean(args.mode));
                     });
             });
 
         this.homey.flow.getActionCard('set_vertical_swing')
             .registerRunListener((args, state) => {
-                return args.device.setCapabilityValue('vertical_swing', args.vertical_swing)
+                return args.device.triggerCapabilityListener('vertical_swing', args.vertical_swing, {})
                     .then(() => {
-                        return args.device.triggerCapabilityListener('vertical_swing', args.vertical_swing, {});
+                        return args.device.setCapabilityValue('vertical_swing', args.vertical_swing);
                     });
             });
 
         this.homey.flow.getActionCard('set_horizontal_swing')
             .registerRunListener((args, state) => {
-                return args.device.setCapabilityValue('horizontal_swing', args.horizontal_swing)
+                return args.device.triggerCapabilityListener('horizontal_swing', args.horizontal_swing, {})
                     .then(() => {
-                        return args.device.triggerCapabilityListener('horizontal_swing', args.horizontal_swing, {});
+                        return args.device.setCapabilityValue('horizontal_swing', args.horizontal_swing);
                     });
             });
 
         this.homey.flow.getActionCard('set_quiet_mode')
             .registerRunListener((args, state) => {
-                return args.device.setCapabilityValue('quiet_mode', args.mode)
+                return args.device.triggerCapabilityListener('quiet_mode', args.mode, {})
                     .then(() => {
-                        return args.device.triggerCapabilityListener('quiet_mode', args.mode, {});
+                        return args.device.setCapabilityValue('quiet_mode', args.mode);
                     });
             });
 
         this.homey.flow.getActionCard('set_health_mode')
             .registerRunListener((args, state) => {
-                return args.device.setCapabilityValue('health_mode', onoffToBoolean(args.mode))
+                return args.device.triggerCapabilityListener('health_mode', onoffToBoolean(args.mode), {})
                     .then(() => {
-                        return args.device.triggerCapabilityListener('health_mode', onoffToBoolean(args.mode), {});
+                        return args.device.setCapabilityValue('health_mode', onoffToBoolean(args.mode));
                     });
             });
 
         this.homey.flow.getActionCard('set_power_save_mode')
             .registerRunListener((args, state) => {
-                return args.device.setCapabilityValue('power_save_mode', onoffToBoolean(args.mode))
+                return args.device.triggerCapabilityListener('power_save_mode', onoffToBoolean(args.mode), {})
                     .then(() => {
-                        return args.device.triggerCapabilityListener('power_save_mode', onoffToBoolean(args.mode), {});
+                        return args.device.setCapabilityValue('power_save_mode', onoffToBoolean(args.mode));
                     });
             });
 
         this.homey.flow.getActionCard('set_sleep_mode')
             .registerRunListener((args, state) => {
-                return args.device.setCapabilityValue('sleep_mode', onoffToBoolean(args.mode))
+                return args.device.triggerCapabilityListener('sleep_mode', onoffToBoolean(args.mode), {})
                     .then(() => {
-                        return args.device.triggerCapabilityListener('sleep_mode', onoffToBoolean(args.mode), {});
+                        return args.device.setCapabilityValue('sleep_mode', onoffToBoolean(args.mode));
                     });
             });
 
         this.homey.flow.getActionCard('set_fresh_air_mode')
             .registerRunListener((args, state) => {
-                return args.device.setCapabilityValue('fresh_air_mode', args.mode)
+                return args.device.triggerCapabilityListener('fresh_air_mode', args.mode, {})
                     .then(() => {
-                        return args.device.triggerCapabilityListener('fresh_air_mode', args.mode, {});
+                        return args.device.setCapabilityValue('fresh_air_mode', args.mode);
                     });
             });
     }

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.gree",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "compatibility": ">=12.0.1",
   "sdk": 3,
   "brandColor": "#ff732e",

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -266,10 +266,10 @@ class GreeHVACDevice extends Homey.Device {
      * @private
      */
     _registerCapabilityListeners() {
-        this.registerCapabilityListener('onoff', (value) => {
+        this.registerCapabilityListener('onoff', async (value) => {
             const rawValue = value ? HVAC.VALUE.power.on : HVAC.VALUE.power.off;
             this.log('[power mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            this._setClientProperty(HVAC.PROPERTY.power, rawValue);
+            await this._setClientProperty(HVAC.PROPERTY.power, rawValue);
 
             if (rawValue === HVAC.VALUE.power.off) {
                 // Set Thermostat mode to Off.
@@ -283,173 +283,132 @@ class GreeHVACDevice extends Homey.Device {
                     this.setCapabilityValue('thermostat_mode', HVAC.VALUE.mode[mode]).catch(this.error);
                 }
             }
-
-            return Promise.resolve();
         });
 
-        this.registerCapabilityListener('target_temperature', (value) => {
+        this.registerCapabilityListener('target_temperature', async (value) => {
             this.log('[temperature change]', `Value: ${value}`);
-            this._setClientProperty(HVAC.PROPERTY.temperature, value);
-
-            return Promise.resolve();
+            await this._setClientProperty(HVAC.PROPERTY.temperature, value);
         });
 
-        this.registerCapabilityListener('thermostat_mode', (value) => {
+        this.registerCapabilityListener('thermostat_mode', async (value) => {
             if (value === 'off') {
                 this.log('[power mode change]', `Value: ${value}`);
-                this._setClientProperty(HVAC.PROPERTY.power, HVAC.VALUE.power.off);
+                await this._setClientProperty(HVAC.PROPERTY.power, HVAC.VALUE.power.off);
                 this.setCapabilityValue('onoff', false).catch(this.error);
             } else {
                 const rawValue = HVAC.VALUE.mode[value];
                 if (rawValue === undefined) {
-                    return Promise.reject(new Error(`Unknown thermostat_mode value: ${JSON.stringify(value)}`));
+                    throw new Error(`Unknown thermostat_mode value: ${JSON.stringify(value)}`);
                 }
                 this.log('[thermostat_mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-                this._setClientProperty(HVAC.PROPERTY.mode, rawValue);
+                await this._setClientProperty(HVAC.PROPERTY.mode, rawValue);
 
                 // Turn on if needed.
                 const properties = this._getCurrentClientProperties();
                 if (properties[HVAC.PROPERTY.power] === HVAC.VALUE.power.off) {
+                    await this._setClientProperty(HVAC.PROPERTY.power, HVAC.VALUE.power.on);
                     this.setCapabilityValue('onoff', true).catch(this.error);
-                    this._setClientProperty(HVAC.PROPERTY.power, HVAC.VALUE.power.on);
                 }
             }
-
-            return Promise.resolve();
         });
 
-        this.registerCapabilityListener('fan_speed', (value) => {
+        this.registerCapabilityListener('fan_speed', async (value) => {
             const rawValue = HVAC.VALUE.fanSpeed[value];
             if (rawValue === undefined) {
-                return Promise.reject(new Error(`Unknown fan speed value: ${JSON.stringify(value)}`));
+                throw new Error(`Unknown fan speed value: ${JSON.stringify(value)}`);
             }
             this.log('[fan speed change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            if (this._setClientProperty(HVAC.PROPERTY.fanSpeed, rawValue)) {
-                this._flowTriggerHvacFanSpeedChanged.trigger(this, { fan_speed: value });
-            }
-
-            return Promise.resolve();
+            await this._setClientProperty(HVAC.PROPERTY.fanSpeed, rawValue);
+            this._flowTriggerHvacFanSpeedChanged.trigger(this, { fan_speed: value });
         });
 
-        this.registerCapabilityListener('turbo_mode', (value) => {
+        this.registerCapabilityListener('turbo_mode', async (value) => {
             const rawValue = value ? HVAC.VALUE.turbo.on : HVAC.VALUE.turbo.off;
             this.log('[turbo mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            if (this._setClientProperty(HVAC.PROPERTY.turbo, rawValue)) {
-                this._flowTriggerTurboModeChanged.trigger(this, { turbo_mode: value });
-            }
-
-            return Promise.resolve();
+            await this._setClientProperty(HVAC.PROPERTY.turbo, rawValue);
+            this._flowTriggerTurboModeChanged.trigger(this, { turbo_mode: value });
         });
 
-        this.registerCapabilityListener('safety_heating', (value) => {
+        this.registerCapabilityListener('safety_heating', async (value) => {
             const rawValue = value ? HVAC.VALUE.safetyHeating.on : HVAC.VALUE.safetyHeating.off;
             this.log('[safety heating change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            if (this._setClientProperty(HVAC.PROPERTY.safetyHeating, rawValue)) {
-                this._flowTriggerSafetyHeatingChanged.trigger(this, { safety_heating: value });
-            }
-
-            return Promise.resolve();
+            await this._setClientProperty(HVAC.PROPERTY.safetyHeating, rawValue);
+            this._flowTriggerSafetyHeatingChanged.trigger(this, { safety_heating: value });
         });
 
-        this.registerCapabilityListener('lights', (value) => {
+        this.registerCapabilityListener('lights', async (value) => {
             const rawValue = value ? HVAC.VALUE.lights.on : HVAC.VALUE.lights.off;
             this.log('[lights change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            if (this._setClientProperty(HVAC.PROPERTY.lights, rawValue)) {
-                this._flowTriggerHvacLightsChanged.trigger(this, { lights: value });
-            }
-
-            return Promise.resolve();
+            await this._setClientProperty(HVAC.PROPERTY.lights, rawValue);
+            this._flowTriggerHvacLightsChanged.trigger(this, { lights: value });
         });
 
-        this.registerCapabilityListener('xfan_mode', (value) => {
+        this.registerCapabilityListener('xfan_mode', async (value) => {
             const rawValue = value ? HVAC.VALUE.blow.on : HVAC.VALUE.blow.off;
             this.log('[xfan mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            if (this._setClientProperty(HVAC.PROPERTY.blow, rawValue)) {
-                this._flowTriggerXFanModeChanged.trigger(this, { xfan_mode: value });
-            }
-
-            return Promise.resolve();
+            await this._setClientProperty(HVAC.PROPERTY.blow, rawValue);
+            this._flowTriggerXFanModeChanged.trigger(this, { xfan_mode: value });
         });
 
-        this.registerCapabilityListener('vertical_swing', (value) => {
+        this.registerCapabilityListener('vertical_swing', async (value) => {
             const rawValue = HVAC.VALUE.swingVert[value];
             if (rawValue === undefined) {
-                return Promise.reject(new Error(`Unknown vertical swing value: ${JSON.stringify(value)}`));
+                throw new Error(`Unknown vertical swing value: ${JSON.stringify(value)}`);
             }
             this.log('[vertical swing change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            if (this._setClientProperty(HVAC.PROPERTY.swingVert, rawValue)) {
-                this._flowTriggerVerticalSwingChanged.trigger(this, { vertical_swing: value });
-            }
-
-            return Promise.resolve();
+            await this._setClientProperty(HVAC.PROPERTY.swingVert, rawValue);
+            this._flowTriggerVerticalSwingChanged.trigger(this, { vertical_swing: value });
         });
 
-        this.registerCapabilityListener('horizontal_swing', (value) => {
+        this.registerCapabilityListener('horizontal_swing', async (value) => {
             const rawValue = HVAC.VALUE.swingHor[value];
             if (rawValue === undefined) {
-                return Promise.reject(new Error(`Unknown horizontal swing value: ${JSON.stringify(value)}`));
+                throw new Error(`Unknown horizontal swing value: ${JSON.stringify(value)}`);
             }
             this.log('[horizontal swing change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            if (this._setClientProperty(HVAC.PROPERTY.swingHor, rawValue)) {
-                this._flowTriggerHorizontalSwingChanged.trigger(this, { horizontal_swing: value });
-            }
-
-            return Promise.resolve();
+            await this._setClientProperty(HVAC.PROPERTY.swingHor, rawValue);
+            this._flowTriggerHorizontalSwingChanged.trigger(this, { horizontal_swing: value });
         });
 
-        this.registerCapabilityListener('quiet_mode', (value) => {
+        this.registerCapabilityListener('quiet_mode', async (value) => {
             const rawValue = HVAC.VALUE.quiet[value];
             if (rawValue === undefined) {
-                return Promise.reject(new Error(`Unknown quiet mode value: ${JSON.stringify(value)}`));
+                throw new Error(`Unknown quiet mode value: ${JSON.stringify(value)}`);
             }
             this.log('[quiet mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            if (this._setClientProperty(HVAC.PROPERTY.quiet, rawValue)) {
-                this._flowTriggerQuietModeChanged.trigger(this, { quiet_mode: value });
-            }
-
-            return Promise.resolve();
+            await this._setClientProperty(HVAC.PROPERTY.quiet, rawValue);
+            this._flowTriggerQuietModeChanged.trigger(this, { quiet_mode: value });
         });
 
-        this.registerCapabilityListener('health_mode', (value) => {
+        this.registerCapabilityListener('health_mode', async (value) => {
             const rawValue = value ? HVAC.VALUE.health.on : HVAC.VALUE.health.off;
             this.log('[health mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            this._setClientProperty(HVAC.PROPERTY.health, rawValue);
+            await this._setClientProperty(HVAC.PROPERTY.health, rawValue);
             this._flowTriggerHealthModeChanged.trigger(this, { health_mode: value });
-
-            return Promise.resolve();
         });
 
-        this.registerCapabilityListener('power_save_mode', (value) => {
+        this.registerCapabilityListener('power_save_mode', async (value) => {
             const rawValue = value ? HVAC.VALUE.powerSave.on : HVAC.VALUE.powerSave.off;
             this.log('[power save mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            if (this._setClientProperty(HVAC.PROPERTY.powerSave, rawValue)) {
-                this._flowTriggerPowerSaveModeChanged.trigger(this, { power_save_mode: value });
-            }
-
-            return Promise.resolve();
+            await this._setClientProperty(HVAC.PROPERTY.powerSave, rawValue);
+            this._flowTriggerPowerSaveModeChanged.trigger(this, { power_save_mode: value });
         });
 
-        this.registerCapabilityListener('sleep_mode', (value) => {
+        this.registerCapabilityListener('sleep_mode', async (value) => {
             const rawValue = value ? HVAC.VALUE.sleep.on : HVAC.VALUE.sleep.off;
             this.log('[sleep mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            if (this._setClientProperty(HVAC.PROPERTY.sleep, rawValue)) {
-                this._flowTriggerSleepModeChanged.trigger(this, { sleep_mode: value });
-            }
-
-            return Promise.resolve();
+            await this._setClientProperty(HVAC.PROPERTY.sleep, rawValue);
+            this._flowTriggerSleepModeChanged.trigger(this, { sleep_mode: value });
         });
 
-        this.registerCapabilityListener('fresh_air_mode', (value) => {
+        this.registerCapabilityListener('fresh_air_mode', async (value) => {
             const rawValue = HVAC.VALUE.air[value];
             if (rawValue === undefined) {
-                return Promise.reject(new Error(`Unknown fresh air mode value: ${JSON.stringify(value)}`));
+                throw new Error(`Unknown fresh air mode value: ${JSON.stringify(value)}`);
             }
             this.log('[fresh air mode change]', `Value: ${value}`, `Raw value: ${rawValue}`);
-            if (this._setClientProperty(HVAC.PROPERTY.air, rawValue)) {
-                this._flowTriggerFreshAirModeChanged.trigger(this, { fresh_air_mode: value });
-            }
-
-            return Promise.resolve();
+            await this._setClientProperty(HVAC.PROPERTY.air, rawValue);
+            this._flowTriggerFreshAirModeChanged.trigger(this, { fresh_air_mode: value });
         });
     }
 
@@ -1030,21 +989,32 @@ class GreeHVACDevice extends Homey.Device {
     }
 
     /**
-     * Set value for the specific property of the HVAC _client
+     * Set value for the specific property of the HVAC _client.
+     *
+     * Rejects when the command could not be delivered to the HVAC — either
+     * because the client is not connected, or because the underlying
+     * `setProperty` call fails (e.g. the socket is gone while the client
+     * object still exists during a reconnect, yielding ClientNotConnectedError).
+     * Capability listeners propagate this rejection so Homey reverts the
+     * capability to its previous value.
      *
      * @param property
      * @param value
-     * @returns {boolean} true when the command was sent to the HVAC
+     * @returns {Promise<void>} resolves once the command was sent to the HVAC
      * @private
      */
-    _setClientProperty(property, value) {
+    async _setClientProperty(property, value) {
         if (!this._client) {
             this.log('[set property]', `Skip setting "${property}". Client is not connected`);
-            return false;
+            throw new Error(this.homey.__('error.not_connected'));
         }
 
-        this._client.setProperty(property, value);
-        return true;
+        try {
+            await this._client.setProperty(property, value);
+        } catch (err) {
+            this.log('[set property]', `Failed to set "${property}":`, err.message);
+            throw new Error(this.homey.__('error.not_connected'));
+        }
     }
 
     reconnect() {

--- a/locales/da.json
+++ b/locales/da.json
@@ -16,6 +16,7 @@
     },
     "error": {
         "offline": "Din HVAC gik offline. Forsøger at genoprette forbindelsen...",
+        "not_connected": "HVAC er ikke tilsluttet. Ændringen kunne ikke anvendes.",
         "invalid_static_ip": "Ugyldig IP-adresse. Indtast en gyldig IPv4-adresse, eller lad feltet være tomt for at bruge automatisk registrering."
     },
     "deprecated": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -16,6 +16,7 @@
     },
     "error": {
         "offline": "Deine Klimaanlage ist offline gegangen. Es wird versucht, die Verbindung wiederherzustellen...",
+        "not_connected": "Die Klimaanlage ist nicht verbunden. Die Änderung konnte nicht angewendet werden.",
         "invalid_static_ip": "Ungültige IP-Adresse. Gib eine gültige IPv4-Adresse ein oder lass das Feld leer, um die automatische Erkennung zu verwenden."
     },
     "deprecated": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -16,6 +16,7 @@
     },
     "error": {
         "offline": "Your HVAC went offline. Trying to reconnect...",
+        "not_connected": "The HVAC is not connected. The change could not be applied.",
         "invalid_static_ip": "Invalid IP address. Enter a valid IPv4 address or leave the field empty to use auto-discovery."
     },
     "deprecated": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -16,6 +16,7 @@
     },
     "error": {
         "offline": "Tu HVAC se ha desconectado. Intentando reconectar...",
+        "not_connected": "El HVAC no está conectado. No se pudo aplicar el cambio.",
         "invalid_static_ip": "Dirección IP no válida. Introduce una dirección IPv4 válida o deja el campo vacío para usar la detección automática."
     },
     "deprecated": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -16,6 +16,7 @@
     },
     "error": {
         "offline": "Ton HVAC est passé hors ligne. Tentative de reconnexion...",
+        "not_connected": "Le HVAC n’est pas connecté. La modification n’a pas pu être appliquée.",
         "invalid_static_ip": "Adresse IP invalide. Saisis une adresse IPv4 valide ou laisse le champ vide pour utiliser la détection automatique."
     },
     "deprecated": {

--- a/locales/it.json
+++ b/locales/it.json
@@ -16,6 +16,7 @@
     },
     "error": {
         "offline": "Il tuo condizionatore è andato offline. Tentativo di riconnessione in corso...",
+        "not_connected": "Il condizionatore non è connesso. La modifica non è stata applicata.",
         "invalid_static_ip": "Indirizzo IP non valido. Inserisci un indirizzo IPv4 valido o lascia vuoto il campo per usare il rilevamento automatico."
     },
     "deprecated": {

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -16,6 +16,7 @@
     },
     "error": {
         "offline": "HVAC가 오프라인 상태가 되었습니다. 다시 연결하는 중...",
+        "not_connected": "HVAC가 연결되어 있지 않습니다. 변경 사항을 적용할 수 없습니다.",
         "invalid_static_ip": "잘못된 IP 주소입니다. 유효한 IPv4 주소를 입력하거나 자동 검색을 사용하려면 필드를 비워 두세요."
     },
     "deprecated": {

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -16,6 +16,7 @@
     },
     "error": {
         "offline": "Je Airco is offline gegaan. Aan het proberen opnieuw te verbinden...",
+        "not_connected": "De airco is niet verbonden. De wijziging kon niet worden toegepast.",
         "invalid_static_ip": "Ongeldig IP-adres. Voer een geldig IPv4-adres in of laat het veld leeg om automatische detectie te gebruiken."
     },
     "deprecated": {

--- a/locales/no.json
+++ b/locales/no.json
@@ -16,6 +16,7 @@
     },
     "error": {
         "offline": "Klimaanlegget ditt ble frakoblet. Prøver å koble til på nytt...",
+        "not_connected": "Klimaanlegget er ikke tilkoblet. Endringen kunne ikke utføres.",
         "invalid_static_ip": "Ugyldig IP-adresse. Angi en gyldig IPv4-adresse eller la feltet stå tomt for å bruke automatisk oppdagelse."
     },
     "deprecated": {

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -16,6 +16,7 @@
     },
     "error": {
         "offline": "Twój klimatyzator przeszedł w tryb offline. Próba ponownego połączenia...",
+        "not_connected": "Klimatyzator nie jest połączony. Nie można zastosować zmiany.",
         "invalid_static_ip": "Nieprawidłowy adres IP. Wprowadź prawidłowy adres IPv4 lub pozostaw pole puste, aby użyć automatycznego wykrywania."
     },
     "deprecated": {

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -16,6 +16,7 @@
     },
     "error": {
         "offline": "Din HVAC har kopplats från. Försöker återansluta...",
+        "not_connected": "HVAC är inte ansluten. Ändringen kunde inte tillämpas.",
         "invalid_static_ip": "Ogiltig IP-adress. Ange en giltig IPv4-adress eller lämna fältet tomt för att använda automatisk identifiering."
     },
     "deprecated": {

--- a/test/app.flowActions.test.js
+++ b/test/app.flowActions.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+describe('GreeHVAC app flow action cards', () => {
+    let GreeHVAC;
+    let app;
+    let runListeners;
+
+    function makeCard(id) {
+        return {
+            registerRunListener: jest.fn((listener) => {
+                runListeners[id] = listener;
+            }),
+        };
+    }
+
+    beforeEach(async () => {
+        jest.resetModules();
+
+        runListeners = {};
+
+        jest.doMock('homey', () => ({
+            App: class App {
+                log() {}
+                error() {}
+            },
+            manifest: { version: '0.0.0-test' },
+        }));
+
+        jest.doMock('homey-log', () => ({
+            Log: jest.fn().mockImplementation(() => ({ captureMessage: jest.fn().mockResolvedValue() })),
+        }));
+
+        GreeHVAC = require('../app');
+
+        app = new GreeHVAC();
+        app.log = jest.fn();
+        app.error = jest.fn();
+        app.homey = {
+            flow: {
+                getConditionCard: jest.fn((id) => makeCard(id)),
+                getActionCard: jest.fn((id) => makeCard(id)),
+                getDeviceTriggerCard: jest.fn((id) => makeCard(id)),
+            },
+            notifications: { createNotification: jest.fn().mockResolvedValue() },
+            __: jest.fn((key) => key),
+        };
+
+        await app.onInit();
+    });
+
+    test('sends the command before writing the capability value on success', async () => {
+        const calls = [];
+        const device = {
+            triggerCapabilityListener: jest.fn(() => {
+                calls.push('trigger');
+                return Promise.resolve();
+            }),
+            setCapabilityValue: jest.fn(() => {
+                calls.push('set');
+                return Promise.resolve();
+            }),
+        };
+
+        await runListeners.set_fan_speed({ device, speed: 'low' }, {});
+
+        expect(device.triggerCapabilityListener).toHaveBeenCalledWith('fan_speed', 'low', {});
+        expect(device.setCapabilityValue).toHaveBeenCalledWith('fan_speed', 'low');
+        // The HVAC command must be attempted before the capability is written,
+        // so a failed command leaves the capability untouched.
+        expect(calls).toEqual(['trigger', 'set']);
+    });
+
+    test('rejects and does not write the capability value when the command fails', async () => {
+        const device = {
+            triggerCapabilityListener: jest.fn().mockRejectedValue(new Error('error.not_connected')),
+            setCapabilityValue: jest.fn().mockResolvedValue(),
+        };
+
+        await expect(runListeners.set_fan_speed({ device, speed: 'low' }, {}))
+            .rejects.toThrow('error.not_connected');
+
+        expect(device.triggerCapabilityListener).toHaveBeenCalledWith('fan_speed', 'low', {});
+        // The command failed, so the capability must not be set to the new value.
+        expect(device.setCapabilityValue).not.toHaveBeenCalled();
+    });
+});

--- a/test/device.flowTriggers.test.js
+++ b/test/device.flowTriggers.test.js
@@ -34,6 +34,7 @@ describe('GreeHVACDevice flow triggers from capability listeners', () => {
             capabilityListeners[capability] = listener;
         });
         device.log = jest.fn();
+        device.homey = { __: jest.fn((key) => key) };
         device._flowTriggerHvacFanSpeedChanged = { trigger: jest.fn() };
         device._flowTriggerTurboModeChanged = { trigger: jest.fn() };
 
@@ -41,7 +42,7 @@ describe('GreeHVACDevice flow triggers from capability listeners', () => {
     });
 
     test('fires the trigger when the command is sent to the HVAC', async () => {
-        device._client = { setProperty: jest.fn() };
+        device._client = { setProperty: jest.fn().mockResolvedValue() };
 
         await capabilityListeners.fan_speed('low');
 
@@ -50,18 +51,18 @@ describe('GreeHVACDevice flow triggers from capability listeners', () => {
             .toHaveBeenCalledWith(device, { fan_speed: 'low' });
     });
 
-    test('does not fire the trigger when the client is not connected', async () => {
+    test('rejects and does not fire the trigger when the client is not connected', async () => {
         device._client = null;
 
-        await capabilityListeners.fan_speed('low');
-        await capabilityListeners.turbo_mode(true);
+        await expect(capabilityListeners.fan_speed('low')).rejects.toThrow('error.not_connected');
+        await expect(capabilityListeners.turbo_mode(true)).rejects.toThrow('error.not_connected');
 
         expect(device._flowTriggerHvacFanSpeedChanged.trigger).not.toHaveBeenCalled();
         expect(device._flowTriggerTurboModeChanged.trigger).not.toHaveBeenCalled();
     });
 
     test('rejects an unknown fan speed value without sending the command or firing the trigger', async () => {
-        device._client = { setProperty: jest.fn() };
+        device._client = { setProperty: jest.fn().mockResolvedValue() };
 
         await expect(capabilityListeners.fan_speed(null))
             .rejects.toThrow('Unknown fan speed value: null');

--- a/test/device.powerListeners.test.js
+++ b/test/device.powerListeners.test.js
@@ -34,6 +34,7 @@ describe('GreeHVACDevice onoff/thermostat_mode listeners', () => {
             capabilityListeners[capability] = listener;
         });
         device.setCapabilityValue = jest.fn().mockResolvedValue();
+        device.homey = { __: jest.fn((key) => key) };
         device.log = jest.fn();
         device.error = jest.fn();
 
@@ -45,28 +46,30 @@ describe('GreeHVACDevice onoff/thermostat_mode listeners', () => {
             device._client = null;
         });
 
-        test('turning on does not throw', async () => {
-            await expect(capabilityListeners.onoff(true)).resolves.toBeUndefined();
+        test('turning on rejects so Homey reverts the capability', async () => {
+            await expect(capabilityListeners.onoff(true)).rejects.toThrow('error.not_connected');
 
-            // No known mode to restore, so thermostat_mode should stay untouched
-            expect(device.setCapabilityValue).not.toHaveBeenCalledWith('thermostat_mode', expect.anything());
+            // The command was not delivered, so no secondary state is written
+            expect(device.setCapabilityValue).not.toHaveBeenCalled();
         });
 
-        test('turning off does not throw and sets thermostat_mode to off', async () => {
-            await expect(capabilityListeners.onoff(false)).resolves.toBeUndefined();
+        test('turning off rejects and does not write thermostat_mode', async () => {
+            await expect(capabilityListeners.onoff(false)).rejects.toThrow('error.not_connected');
 
-            expect(device.setCapabilityValue).toHaveBeenCalledWith('thermostat_mode', 'off');
+            expect(device.setCapabilityValue).not.toHaveBeenCalled();
         });
 
-        test('changing thermostat_mode does not throw', async () => {
-            await expect(capabilityListeners.thermostat_mode('cool')).resolves.toBeUndefined();
+        test('changing thermostat_mode rejects', async () => {
+            await expect(capabilityListeners.thermostat_mode('cool')).rejects.toThrow('error.not_connected');
+
+            expect(device.setCapabilityValue).not.toHaveBeenCalled();
         });
     });
 
     describe('when the client is connected', () => {
         beforeEach(() => {
             device._client = {
-                setProperty: jest.fn(),
+                setProperty: jest.fn().mockResolvedValue(),
                 _properties: { Pow: 0, Mod: 1 },
                 _transformer: {
                     fromVendor: jest.fn(() => ({ power: 'off', mode: 'cool' })),
@@ -87,6 +90,39 @@ describe('GreeHVACDevice onoff/thermostat_mode listeners', () => {
             expect(device._client.setProperty).toHaveBeenCalledWith('mode', 'heat');
             expect(device._client.setProperty).toHaveBeenCalledWith('power', 'on');
             expect(device.setCapabilityValue).toHaveBeenCalledWith('onoff', true);
+        });
+    });
+
+    describe('when the client socket is gone but the client still exists', () => {
+        let unhandledRejection;
+
+        beforeEach(() => {
+            unhandledRejection = jest.fn();
+            process.on('unhandledRejection', unhandledRejection);
+
+            device._client = {
+                setProperty: jest.fn().mockRejectedValue(new Error('Client is not connected to the HVAC')),
+                _properties: {},
+                _transformer: {
+                    fromVendor: jest.fn(() => ({})),
+                },
+            };
+        });
+
+        afterEach(() => {
+            process.removeListener('unhandledRejection', unhandledRejection);
+        });
+
+        test('turning on rejects (so Homey reverts) without an unhandled rejection', async () => {
+            await expect(capabilityListeners.onoff(true)).rejects.toThrow('error.not_connected');
+
+            expect(device._client.setProperty).toHaveBeenCalledWith('power', 'on');
+            // The command failed, so thermostat_mode must not be written optimistically
+            expect(device.setCapabilityValue).not.toHaveBeenCalled();
+
+            // Let any pending microtasks settle and confirm nothing escaped unhandled.
+            await Promise.resolve();
+            expect(unhandledRejection).not.toHaveBeenCalled();
         });
     });
 });

--- a/test/device.powerSaveMode.test.js
+++ b/test/device.powerSaveMode.test.js
@@ -60,11 +60,11 @@ describe('GreeHVACDevice power_save_mode listener', () => {
         expect(device._flowTriggerPowerSaveModeChanged.trigger).toHaveBeenCalledWith(device, { power_save_mode: false });
     });
 
-    test('does not trigger the flow when the client is not connected', async () => {
-        device._setClientProperty.mockReturnValue(false);
+    test('rejects and does not trigger the flow when the command fails', async () => {
+        device._setClientProperty.mockRejectedValue(new Error('error.not_connected'));
         device._registerCapabilityListeners();
 
-        await capabilityListeners.power_save_mode(true);
+        await expect(capabilityListeners.power_save_mode(true)).rejects.toThrow('error.not_connected');
 
         expect(device._flowTriggerPowerSaveModeChanged.trigger).not.toHaveBeenCalled();
     });

--- a/test/device.sleepMode.test.js
+++ b/test/device.sleepMode.test.js
@@ -60,11 +60,11 @@ describe('GreeHVACDevice sleep_mode listener', () => {
         expect(device._flowTriggerSleepModeChanged.trigger).toHaveBeenCalledWith(device, { sleep_mode: false });
     });
 
-    test('does not trigger the flow when the client is not connected', async () => {
-        device._setClientProperty.mockReturnValue(false);
+    test('rejects and does not trigger the flow when the command fails', async () => {
+        device._setClientProperty.mockRejectedValue(new Error('error.not_connected'));
         device._registerCapabilityListeners();
 
-        await capabilityListeners.sleep_mode(true);
+        await expect(capabilityListeners.sleep_mode(true)).rejects.toThrow('error.not_connected');
 
         expect(device._flowTriggerSleepModeChanged.trigger).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## What & why

Fixes the unhandled promise rejection reported in Sentry [GREE-HOMEY-7](https://homey-gree.sentry.io/issues/GREE-HOMEY-7) — `ClientNotConnectedError: Client is not connected to the HVAC`.

`_setClientProperty` was fire-and-forget with no `.catch()`. When `gree-hvac-client`'s `setProperty()` rejects — the client object exists but its socket is gone during a reconnect window — the rejection had nowhere to go and became an unhandled promise rejection.

## Change

Rather than just swallowing the rejection, this makes the failure **propagate** so the UI stays honest:

- `_setClientProperty` is now `async` and **rejects** when the command can't be delivered (no client, or `setProperty()` throws), with a localized `error.not_connected` message.
- All 16 capability listeners are now `async` and `await` it, so a failed command bubbles up to Homey, which **reverts the capability to its previous value** instead of silently showing the new one. Flow triggers fire only *after* the command succeeds.
- **Flow action cards** (`app.js`): reversed the order so the HVAC command is attempted (`triggerCapabilityListener`) *before* the capability value is written. Previously the value was set optimistically first, so a failed command left the capability showing the new value even though the Flow errored. Now a failed command leaves the capability at its real value and the Flow still errors — consistent with UI toggles.
- Added `error.not_connected` to all 11 locales.
- Bumped app version to **1.1.2** (both `.homeycompose/app.json` and generated `app.json`) with a `.homeychangelog.json` entry across all locales.

## Behavior change to be aware of

Previously, toggling a capability (via UI or Flow) while the client was momentarily disconnected silently "succeeded". Now it visibly bounces back / the Flow errors. This is the intended effect, but it is user-visible.

## Testing

- `npm test` green — ESLint clean, 101/101 Jest tests pass.
- Updated the previously boolean-gated device tests to assert reject-on-failure, plus a regression test for the exact socket-gone-but-client-exists scenario from the Sentry event.
- New `test/app.flowActions.test.js` asserts the command is attempted before the capability write, and that a failed command rejects the Flow without writing the capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)