### PR TITLE
Add per-device connection timeout settings (#95)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -544,5 +544,18 @@
     "da": "Fortryd en betjeningsændring og vis en notifikation, når HVAC er offline, i stedet for i stilhed at lade som om den blev anvendt",
     "pl": "Cofnij zmianę sterowania i wyświetl powiadomienie, gdy klimatyzator jest offline, zamiast po cichu udawać, że została zastosowana",
     "ko": "HVAC가 오프라인일 때 변경이 적용된 것처럼 조용히 처리하지 않고, 제어 변경을 되돌리고 알림을 표시합니다"
+  },
+  "1.2.0": {
+    "en": "Add per-device connection timeout settings so slow HVACs are no longer shown as disconnected",
+    "nl": "Instellingen voor verbindingstime-outs per apparaat toegevoegd, zodat trage airco's niet langer als niet-verbonden worden weergegeven",
+    "de": "Einstellungen für Verbindungs-Timeouts pro Gerät hinzugefügt, damit langsame Klimaanlagen nicht mehr als getrennt angezeigt werden",
+    "fr": "Ajout de réglages de délai de connexion par appareil pour que les climatiseurs lents ne soient plus affichés comme déconnectés",
+    "it": "Aggiunte impostazioni di timeout della connessione per dispositivo, così i condizionatori lenti non vengono più mostrati come disconnessi",
+    "sv": "Lade till inställningar för anslutningstimeout per enhet så att långsamma HVAC:er inte längre visas som frånkopplade",
+    "no": "La til innstillinger for tilkoblingstidsavbrudd per enhet slik at trege klimaanlegg ikke lenger vises som frakoblet",
+    "es": "Se añaden ajustes de tiempo de espera de conexión por dispositivo para que los HVAC lentos ya no aparezcan como desconectados",
+    "da": "Tilføjet indstillinger for forbindelsestimeout pr. enhed, så langsomme HVAC'er ikke længere vises som afbrudt",
+    "pl": "Dodano ustawienia limitu czasu połączenia dla poszczególnych urządzeń, aby wolne klimatyzatory nie były już pokazywane jako odłączone",
+    "ko": "기기별 연결 시간 초과 설정을 추가하여 느린 HVAC가 더 이상 연결 끊김으로 표시되지 않도록 했습니다"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.gree",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "compatibility": ">=12.0.1",
   "sdk": 3,
   "brandColor": "#ff732e",

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.gree",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "compatibility": ">=12.0.1",
   "sdk": 3,
   "brandColor": "#ff732e",
@@ -3689,6 +3689,168 @@
               "step": 1,
               "units": {
                 "en": "°C"
+              }
+            }
+          ]
+        },
+        {
+          "type": "group",
+          "label": {
+            "en": "Connection",
+            "nl": "Verbinding",
+            "de": "Verbindung",
+            "fr": "Connexion",
+            "it": "Connessione",
+            "sv": "Anslutning",
+            "no": "Tilkobling",
+            "es": "Conexión",
+            "da": "Forbindelse",
+            "pl": "Połączenie",
+            "ko": "연결"
+          },
+          "children": [
+            {
+              "id": "polling_interval",
+              "type": "number",
+              "label": {
+                "en": "Polling interval",
+                "nl": "Pollinginterval",
+                "de": "Abfrageintervall",
+                "fr": "Intervalle d'interrogation",
+                "it": "Intervallo di polling",
+                "sv": "Pollningsintervall",
+                "no": "Pollingintervall",
+                "es": "Intervalo de sondeo",
+                "da": "Pollinginterval",
+                "pl": "Interwał odpytywania",
+                "ko": "폴링 간격"
+              },
+              "hint": {
+                "en": "How often the app asks the HVAC for its current status. Increase it if the device is often shown as disconnected. Default: 3500 ms.",
+                "nl": "Hoe vaak de app de huidige status van de HVAC opvraagt. Verhoog dit als het apparaat vaak als niet-verbonden wordt weergegeven. Standaard: 3500 ms.",
+                "de": "Wie oft die App den aktuellen Status der Klimaanlage abfragt. Erhöhe den Wert, wenn das Gerät oft als getrennt angezeigt wird. Standard: 3500 ms.",
+                "fr": "Fréquence à laquelle l'application demande l'état actuel du climatiseur. Augmentez-la si l'appareil est souvent affiché comme déconnecté. Par défaut : 3500 ms.",
+                "it": "Con quale frequenza l'app richiede lo stato attuale del condizionatore. Aumentalo se il dispositivo viene spesso mostrato come disconnesso. Predefinito: 3500 ms.",
+                "sv": "Hur ofta appen frågar HVAC:en om dess aktuella status. Öka värdet om enheten ofta visas som frånkopplad. Standard: 3500 ms.",
+                "no": "Hvor ofte appen spør klimaanlegget om gjeldende status. Øk verdien hvis enheten ofte vises som frakoblet. Standard: 3500 ms.",
+                "es": "Con qué frecuencia la app solicita el estado actual del HVAC. Auméntalo si el dispositivo aparece a menudo como desconectado. Predeterminado: 3500 ms.",
+                "da": "Hvor ofte appen beder HVAC'en om dens aktuelle status. Forøg værdien, hvis enheden ofte vises som afbrudt. Standard: 3500 ms.",
+                "pl": "Jak często aplikacja odpytuje klimatyzator o bieżący stan. Zwiększ tę wartość, jeśli urządzenie często pokazywane jest jako odłączone. Domyślnie: 3500 ms.",
+                "ko": "앱이 HVAC에 현재 상태를 요청하는 빈도입니다. 기기가 자주 연결 끊김으로 표시되면 값을 늘리세요. 기본값: 3500 ms."
+              },
+              "value": 3500,
+              "min": 1000,
+              "step": 100,
+              "units": {
+                "en": "ms"
+              }
+            },
+            {
+              "id": "polling_timeout",
+              "type": "number",
+              "label": {
+                "en": "Polling timeout",
+                "nl": "Pollingtime-out",
+                "de": "Abfrage-Timeout",
+                "fr": "Délai d'interrogation",
+                "it": "Timeout di polling",
+                "sv": "Pollningstimeout",
+                "no": "Polling-tidsavbrudd",
+                "es": "Tiempo de espera de sondeo",
+                "da": "Polling-timeout",
+                "pl": "Limit czasu odpytywania",
+                "ko": "폴링 시간 초과"
+              },
+              "hint": {
+                "en": "How long to wait for a status reply before the HVAC is treated as not responding. Increase it for slow or distant devices. Default: 3000 ms.",
+                "nl": "Hoe lang op een statusantwoord wordt gewacht voordat de HVAC als niet-reagerend wordt beschouwd. Verhoog dit voor trage of veraf gelegen apparaten. Standaard: 3000 ms.",
+                "de": "Wie lange auf eine Statusantwort gewartet wird, bevor die Klimaanlage als nicht reagierend gilt. Erhöhe den Wert für langsame oder weit entfernte Geräte. Standard: 3000 ms.",
+                "fr": "Durée d'attente d'une réponse d'état avant de considérer le climatiseur comme ne répondant pas. Augmentez-la pour les appareils lents ou éloignés. Par défaut : 3000 ms.",
+                "it": "Per quanto tempo attendere una risposta di stato prima di considerare il condizionatore non responsivo. Aumentalo per dispositivi lenti o distanti. Predefinito: 3000 ms.",
+                "sv": "Hur länge appen väntar på ett statussvar innan HVAC:en anses inte svara. Öka värdet för långsamma eller avlägsna enheter. Standard: 3000 ms.",
+                "no": "Hvor lenge appen venter på et statussvar før klimaanlegget regnes som at det ikke svarer. Øk verdien for trege eller fjerne enheter. Standard: 3000 ms.",
+                "es": "Cuánto tiempo se espera una respuesta de estado antes de considerar que el HVAC no responde. Auméntalo para dispositivos lentos o lejanos. Predeterminado: 3000 ms.",
+                "da": "Hvor længe der ventes på et statussvar, før HVAC'en betragtes som ikke-svarende. Forøg værdien for langsomme eller fjerne enheder. Standard: 3000 ms.",
+                "pl": "Jak długo czekać na odpowiedź o stanie, zanim klimatyzator zostanie uznany za nieodpowiadający. Zwiększ dla wolnych lub odległych urządzeń. Domyślnie: 3000 ms.",
+                "ko": "HVAC를 응답 없음으로 간주하기 전에 상태 응답을 기다리는 시간입니다. 느리거나 멀리 있는 기기의 경우 값을 늘리세요. 기본값: 3000 ms."
+              },
+              "value": 3000,
+              "min": 500,
+              "step": 100,
+              "units": {
+                "en": "ms"
+              }
+            },
+            {
+              "id": "connect_timeout",
+              "type": "number",
+              "label": {
+                "en": "Connection timeout",
+                "nl": "Verbindingstime-out",
+                "de": "Verbindungs-Timeout",
+                "fr": "Délai de connexion",
+                "it": "Timeout di connessione",
+                "sv": "Anslutningstimeout",
+                "no": "Tilkoblingstidsavbrudd",
+                "es": "Tiempo de espera de conexión",
+                "da": "Forbindelsestimeout",
+                "pl": "Limit czasu połączenia",
+                "ko": "연결 시간 초과"
+              },
+              "hint": {
+                "en": "How long to wait when establishing a connection to the HVAC before retrying. Default: 5000 ms.",
+                "nl": "Hoe lang wordt gewacht bij het tot stand brengen van een verbinding met de HVAC voordat opnieuw wordt geprobeerd. Standaard: 5000 ms.",
+                "de": "Wie lange beim Aufbau einer Verbindung zur Klimaanlage gewartet wird, bevor ein neuer Versuch erfolgt. Standard: 5000 ms.",
+                "fr": "Durée d'attente lors de l'établissement d'une connexion au climatiseur avant de réessayer. Par défaut : 5000 ms.",
+                "it": "Per quanto tempo attendere durante l'instaurazione di una connessione al condizionatore prima di riprovare. Predefinito: 5000 ms.",
+                "sv": "Hur länge appen väntar när en anslutning till HVAC:en upprättas innan den försöker igen. Standard: 5000 ms.",
+                "no": "Hvor lenge appen venter når en tilkobling til klimaanlegget opprettes før den prøver igjen. Standard: 5000 ms.",
+                "es": "Cuánto tiempo se espera al establecer una conexión con el HVAC antes de reintentar. Predeterminado: 5000 ms.",
+                "da": "Hvor længe der ventes ved oprettelse af en forbindelse til HVAC'en, før der forsøges igen. Standard: 5000 ms.",
+                "pl": "Jak długo czekać podczas nawiązywania połączenia z klimatyzatorem przed ponowną próbą. Domyślnie: 5000 ms.",
+                "ko": "HVAC에 연결을 설정할 때 다시 시도하기 전에 기다리는 시간입니다. 기본값: 5000 ms."
+              },
+              "value": 5000,
+              "min": 1000,
+              "step": 100,
+              "units": {
+                "en": "ms"
+              }
+            },
+            {
+              "id": "no_response_reconnect_timeout",
+              "type": "number",
+              "label": {
+                "en": "Reconnect after no response",
+                "nl": "Opnieuw verbinden na geen reactie",
+                "de": "Erneut verbinden nach keiner Antwort",
+                "fr": "Reconnexion après absence de réponse",
+                "it": "Riconnessione dopo nessuna risposta",
+                "sv": "Återanslut efter uteblivet svar",
+                "no": "Koble til på nytt etter manglende svar",
+                "es": "Reconectar tras falta de respuesta",
+                "da": "Genopret forbindelse efter manglende svar",
+                "pl": "Ponowne łączenie po braku odpowiedzi",
+                "ko": "응답 없을 때 재연결"
+              },
+              "hint": {
+                "en": "How long the HVAC may stay unresponsive before the app drops the connection and restarts discovery (helps recover when the device changes its IP address). Default: 60000 ms.",
+                "nl": "Hoe lang de HVAC niet mag reageren voordat de app de verbinding verbreekt en de detectie herstart (helpt bij herstel wanneer het apparaat zijn IP-adres wijzigt). Standaard: 60000 ms.",
+                "de": "Wie lange die Klimaanlage nicht reagieren darf, bevor die App die Verbindung trennt und die Erkennung neu startet (hilft bei der Wiederherstellung, wenn das Gerät seine IP-Adresse ändert). Standard: 60000 ms.",
+                "fr": "Durée pendant laquelle le climatiseur peut rester sans réponse avant que l'application ne coupe la connexion et relance la détection (utile lorsque l'appareil change d'adresse IP). Par défaut : 60000 ms.",
+                "it": "Per quanto tempo il condizionatore può restare non responsivo prima che l'app interrompa la connessione e riavvii il rilevamento (aiuta il ripristino quando il dispositivo cambia indirizzo IP). Predefinito: 60000 ms.",
+                "sv": "Hur länge HVAC:en får vara oåtkomlig innan appen bryter anslutningen och startar om identifieringen (hjälper till att återställa när enheten byter IP-adress). Standard: 60000 ms.",
+                "no": "Hvor lenge klimaanlegget kan være uten respons før appen bryter tilkoblingen og starter oppdagelsen på nytt (hjelper med gjenoppretting når enheten endrer IP-adresse). Standard: 60000 ms.",
+                "es": "Cuánto tiempo puede el HVAC permanecer sin responder antes de que la app corte la conexión y reinicie la detección (ayuda a recuperarse cuando el dispositivo cambia su dirección IP). Predeterminado: 60000 ms.",
+                "da": "Hvor længe HVAC'en må være uden svar, før appen afbryder forbindelsen og genstarter registreringen (hjælper med at genoprette, når enheden ændrer sin IP-adresse). Standard: 60000 ms.",
+                "pl": "Jak długo klimatyzator może nie odpowiadać, zanim aplikacja rozłączy połączenie i ponownie uruchomi wykrywanie (pomaga w odzyskiwaniu, gdy urządzenie zmienia adres IP). Domyślnie: 60000 ms.",
+                "ko": "HVAC가 응답하지 않는 상태로 있을 수 있는 시간으로, 이후 앱이 연결을 끊고 검색을 다시 시작합니다(기기가 IP 주소를 변경할 때 복구에 도움). 기본값: 60000 ms."
+              },
+              "value": 60000,
+              "min": 10000,
+              "step": 1000,
+              "units": {
+                "en": "ms"
               }
             }
           ]

--- a/app.json
+++ b/app.json
@@ -3762,17 +3762,17 @@
                 "ko": "폴링 시간 초과"
               },
               "hint": {
-                "en": "How long to wait for a status reply before the HVAC is treated as not responding. Increase it for slow or distant devices. Default: 3000 ms.",
-                "nl": "Hoe lang op een statusantwoord wordt gewacht voordat de HVAC als niet-reagerend wordt beschouwd. Verhoog dit voor trage of veraf gelegen apparaten. Standaard: 3000 ms.",
-                "de": "Wie lange auf eine Statusantwort gewartet wird, bevor die Klimaanlage als nicht reagierend gilt. Erhöhe den Wert für langsame oder weit entfernte Geräte. Standard: 3000 ms.",
-                "fr": "Durée d'attente d'une réponse d'état avant de considérer le climatiseur comme ne répondant pas. Augmentez-la pour les appareils lents ou éloignés. Par défaut : 3000 ms.",
-                "it": "Per quanto tempo attendere una risposta di stato prima di considerare il condizionatore non responsivo. Aumentalo per dispositivi lenti o distanti. Predefinito: 3000 ms.",
-                "sv": "Hur länge appen väntar på ett statussvar innan HVAC:en anses inte svara. Öka värdet för långsamma eller avlägsna enheter. Standard: 3000 ms.",
-                "no": "Hvor lenge appen venter på et statussvar før klimaanlegget regnes som at det ikke svarer. Øk verdien for trege eller fjerne enheter. Standard: 3000 ms.",
-                "es": "Cuánto tiempo se espera una respuesta de estado antes de considerar que el HVAC no responde. Auméntalo para dispositivos lentos o lejanos. Predeterminado: 3000 ms.",
-                "da": "Hvor længe der ventes på et statussvar, før HVAC'en betragtes som ikke-svarende. Forøg værdien for langsomme eller fjerne enheder. Standard: 3000 ms.",
-                "pl": "Jak długo czekać na odpowiedź o stanie, zanim klimatyzator zostanie uznany za nieodpowiadający. Zwiększ dla wolnych lub odległych urządzeń. Domyślnie: 3000 ms.",
-                "ko": "HVAC를 응답 없음으로 간주하기 전에 상태 응답을 기다리는 시간입니다. 느리거나 멀리 있는 기기의 경우 값을 늘리세요. 기본값: 3000 ms."
+                "en": "How long to wait for a status reply before the HVAC is treated as not responding. Increase it for slow or distant devices. Must stay below the polling interval. Default: 3000 ms.",
+                "nl": "Hoe lang op een statusantwoord wordt gewacht voordat de HVAC als niet-reagerend wordt beschouwd. Verhoog dit voor trage of veraf gelegen apparaten. Moet lager blijven dan het pollinginterval. Standaard: 3000 ms.",
+                "de": "Wie lange auf eine Statusantwort gewartet wird, bevor die Klimaanlage als nicht reagierend gilt. Erhöhe den Wert für langsame oder weit entfernte Geräte. Muss unter dem Abfrageintervall bleiben. Standard: 3000 ms.",
+                "fr": "Durée d'attente d'une réponse d'état avant de considérer le climatiseur comme ne répondant pas. Augmentez-la pour les appareils lents ou éloignés. Doit rester inférieur à l'intervalle d'interrogation. Par défaut : 3000 ms.",
+                "it": "Per quanto tempo attendere una risposta di stato prima di considerare il condizionatore non responsivo. Aumentalo per dispositivi lenti o distanti. Deve restare inferiore all'intervallo di polling. Predefinito: 3000 ms.",
+                "sv": "Hur länge appen väntar på ett statussvar innan HVAC:en anses inte svara. Öka värdet för långsamma eller avlägsna enheter. Måste hållas under pollningsintervallet. Standard: 3000 ms.",
+                "no": "Hvor lenge appen venter på et statussvar før klimaanlegget regnes som at det ikke svarer. Øk verdien for trege eller fjerne enheter. Må holdes under pollingintervallet. Standard: 3000 ms.",
+                "es": "Cuánto tiempo se espera una respuesta de estado antes de considerar que el HVAC no responde. Auméntalo para dispositivos lentos o lejanos. Debe mantenerse por debajo del intervalo de sondeo. Predeterminado: 3000 ms.",
+                "da": "Hvor længe der ventes på et statussvar, før HVAC'en betragtes som ikke-svarende. Forøg værdien for langsomme eller fjerne enheder. Skal holdes under pollinginterval. Standard: 3000 ms.",
+                "pl": "Jak długo czekać na odpowiedź o stanie, zanim klimatyzator zostanie uznany za nieodpowiadający. Zwiększ dla wolnych lub odległych urządzeń. Musi pozostać poniżej interwału odpytywania. Domyślnie: 3000 ms.",
+                "ko": "HVAC를 응답 없음으로 간주하기 전에 상태 응답을 기다리는 시간입니다. 느리거나 멀리 있는 기기의 경우 값을 늘리세요. 폴링 간격보다 작아야 합니다. 기본값: 3000 ms."
               },
               "value": 3000,
               "min": 500,

--- a/app.json
+++ b/app.json
@@ -3696,17 +3696,30 @@
         {
           "type": "group",
           "label": {
-            "en": "Connection",
-            "nl": "Verbinding",
-            "de": "Verbindung",
-            "fr": "Connexion",
-            "it": "Connessione",
-            "sv": "Anslutning",
-            "no": "Tilkobling",
-            "es": "Conexión",
-            "da": "Forbindelse",
-            "pl": "Połączenie",
-            "ko": "연결"
+            "en": "Connection (advanced)",
+            "nl": "Verbinding (geavanceerd)",
+            "de": "Verbindung (erweitert)",
+            "fr": "Connexion (avancé)",
+            "it": "Connessione (avanzato)",
+            "sv": "Anslutning (avancerat)",
+            "no": "Tilkobling (avansert)",
+            "es": "Conexión (avanzado)",
+            "da": "Forbindelse (avanceret)",
+            "pl": "Połączenie (zaawansowane)",
+            "ko": "연결 (고급)"
+          },
+          "hint": {
+            "en": "Advanced settings. The defaults work for most devices — only change them if your HVAC is often shown as disconnected.",
+            "nl": "Geavanceerde instellingen. De standaardwaarden werken voor de meeste apparaten — wijzig ze alleen als je HVAC vaak als niet-verbonden wordt weergegeven.",
+            "de": "Erweiterte Einstellungen. Die Standardwerte funktionieren für die meisten Geräte — ändere sie nur, wenn deine Klimaanlage oft als getrennt angezeigt wird.",
+            "fr": "Réglages avancés. Les valeurs par défaut conviennent à la plupart des appareils — ne les modifiez que si votre climatiseur est souvent affiché comme déconnecté.",
+            "it": "Impostazioni avanzate. I valori predefiniti vanno bene per la maggior parte dei dispositivi — modificale solo se il condizionatore viene spesso mostrato come disconnesso.",
+            "sv": "Avancerade inställningar. Standardvärdena fungerar för de flesta enheter — ändra dem bara om din HVAC ofta visas som frånkopplad.",
+            "no": "Avanserte innstillinger. Standardverdiene fungerer for de fleste enheter — endre dem bare hvis klimaanlegget ofte vises som frakoblet.",
+            "es": "Ajustes avanzados. Los valores predeterminados funcionan para la mayoría de los dispositivos — cámbialos solo si tu HVAC aparece a menudo como desconectado.",
+            "da": "Avancerede indstillinger. Standardværdierne fungerer for de fleste enheder — ret dem kun, hvis din HVAC ofte vises som afbrudt.",
+            "pl": "Ustawienia zaawansowane. Wartości domyślne działają dla większości urządzeń — zmień je tylko, jeśli Twój klimatyzator jest często pokazywany jako odłączony.",
+            "ko": "고급 설정입니다. 기본값은 대부분의 기기에서 작동합니다 — HVAC가 자주 연결 끊김으로 표시되는 경우에만 변경하세요."
           },
           "children": [
             {

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
-  "id": "com.gree",
+  "id": "com.gree.test",
   "version": "1.2.0",
   "compatibility": ">=12.0.1",
   "sdk": 3,
@@ -3707,19 +3707,6 @@
             "da": "Forbindelse (avanceret)",
             "pl": "Połączenie (zaawansowane)",
             "ko": "연결 (고급)"
-          },
-          "hint": {
-            "en": "Advanced settings. The defaults work for most devices — only change them if your HVAC is often shown as disconnected.",
-            "nl": "Geavanceerde instellingen. De standaardwaarden werken voor de meeste apparaten — wijzig ze alleen als je HVAC vaak als niet-verbonden wordt weergegeven.",
-            "de": "Erweiterte Einstellungen. Die Standardwerte funktionieren für die meisten Geräte — ändere sie nur, wenn deine Klimaanlage oft als getrennt angezeigt wird.",
-            "fr": "Réglages avancés. Les valeurs par défaut conviennent à la plupart des appareils — ne les modifiez que si votre climatiseur est souvent affiché comme déconnecté.",
-            "it": "Impostazioni avanzate. I valori predefiniti vanno bene per la maggior parte dei dispositivi — modificale solo se il condizionatore viene spesso mostrato come disconnesso.",
-            "sv": "Avancerade inställningar. Standardvärdena fungerar för de flesta enheter — ändra dem bara om din HVAC ofta visas som frånkopplad.",
-            "no": "Avanserte innstillinger. Standardverdiene fungerer for de fleste enheter — endre dem bare hvis klimaanlegget ofte vises som frakoblet.",
-            "es": "Ajustes avanzados. Los valores predeterminados funcionan para la mayoría de los dispositivos — cámbialos solo si tu HVAC aparece a menudo como desconectado.",
-            "da": "Avancerede indstillinger. Standardværdierne fungerer for de fleste enheder — ret dem kun, hvis din HVAC ofte vises som afbrudt.",
-            "pl": "Ustawienia zaawansowane. Wartości domyślne działają dla większości urządzeń — zmień je tylko, jeśli Twój klimatyzator jest często pokazywany jako odłączony.",
-            "ko": "고급 설정입니다. 기본값은 대부분의 기기에서 작동합니다 — HVAC가 자주 연결 끊김으로 표시되는 경우에만 변경하세요."
           },
           "children": [
             {

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -8,18 +8,39 @@ const { compareBoolProperties, isValidIpv4 } = require('../../utils');
 // Interval between trying to found HVAC in network (ms)
 const LOOKING_FOR_DEVICE_TIME_INTERVAL = 5000;
 
+// Defaults for the user-configurable connection timeouts (ms). Each has a
+// matching device setting (see driver.compose.json "Connection" group); the
+// constant is used as a fallback for devices whose setting is not stored yet.
+
 // Interval between polling status from HVAC (ms)
-const POLLING_INTERVAL = 3500;
+const DEFAULT_POLLING_INTERVAL = 3500;
 
 // Timeout for response from the HVAC during polling process (ms)
-const POLLING_TIMEOUT = 3000;
+const DEFAULT_POLLING_TIMEOUT = 3000;
 
 // Timeout of the connection to the HVAC (ms)
-const CONNECT_TIMEOUT = 5000;
+const DEFAULT_CONNECT_TIMEOUT = 5000;
 
 // Time without any response from the HVAC after which
 // the connection is dropped and discovery is restarted (ms)
-const NO_RESPONSE_RECONNECT_TIMEOUT = 60 * 1000;
+const DEFAULT_NO_RESPONSE_RECONNECT_TIMEOUT = 60 * 1000;
+
+// Device setting ids (see driver.compose.json).
+const SETTING = {
+    STATIC_IP: 'static_ip',
+    MIN_TARGET_TEMPERATURE: 'min_target_temperature',
+    POLLING_INTERVAL: 'polling_interval',
+    POLLING_TIMEOUT: 'polling_timeout',
+    CONNECT_TIMEOUT: 'connect_timeout',
+    NO_RESPONSE_RECONNECT_TIMEOUT: 'no_response_reconnect_timeout',
+};
+
+// Settings that are only read when the HVAC client is constructed and therefore
+// require a reconnect to take effect.
+const CLIENT_TIMEOUT_SETTINGS = [SETTING.POLLING_INTERVAL, SETTING.POLLING_TIMEOUT, SETTING.CONNECT_TIMEOUT];
+
+// All user-configurable timeout settings (ms).
+const TIMEOUT_SETTINGS = [...CLIENT_TIMEOUT_SETTINGS, SETTING.NO_RESPONSE_RECONNECT_TIMEOUT];
 
 // Bounds for the target_temperature capability. The minimum is user-configurable
 // via the "min_target_temperature" device setting (some heat pumps support 8 °C).
@@ -54,12 +75,18 @@ class GreeHVACDevice extends Homey.Device {
     _noResponseReconnectTimeoutRef = null;
 
     /**
-     * Current static IP setting value, including pending updates from onSettings.
+     * Setting values pending from onSettings, keyed by setting id.
      *
-     * @type {string|undefined}
+     * onSettings runs before Homey persists the new settings but can trigger a
+     * synchronous reconnect; the new values are mirrored here so reads via
+     * _getSetting() pick them up instead of the stale getSetting() value.
+     * onSettings is the only place settings change, so this never diverges from
+     * the persisted state.
+     *
+     * @type {Object}
      * @private
      */
-    _staticIpSetting = undefined;
+    _pendingSettings = {};
 
     async onInit() {
         this.log('Gree device has been inited');
@@ -147,19 +174,36 @@ class GreeHVACDevice extends Homey.Device {
     }
 
     async onSettings({ oldSettings, newSettings, changedKeys }) {
-        if (changedKeys.includes('static_ip') && oldSettings.static_ip !== newSettings.static_ip) {
-            if (newSettings.static_ip && !isValidIpv4(newSettings.static_ip)) {
+        if (changedKeys.includes(SETTING.STATIC_IP) && oldSettings[SETTING.STATIC_IP] !== newSettings[SETTING.STATIC_IP]) {
+            if (newSettings[SETTING.STATIC_IP] && !isValidIpv4(newSettings[SETTING.STATIC_IP])) {
                 throw new Error(this.homey.__('error.invalid_static_ip'));
             }
 
             this.log('[settings]', 'Static IP changed. Reconnecting.');
-            this._staticIpSetting = newSettings.static_ip;
+            this._pendingSettings[SETTING.STATIC_IP] = newSettings[SETTING.STATIC_IP];
             this.reconnect();
         }
 
-        if (changedKeys.includes('min_target_temperature')) {
-            this.log('[settings]', 'Minimum target temperature changed:', newSettings.min_target_temperature);
-            await this._applyTargetTemperatureRange(newSettings.min_target_temperature);
+        if (changedKeys.includes(SETTING.MIN_TARGET_TEMPERATURE)) {
+            this.log('[settings]', 'Minimum target temperature changed:', newSettings[SETTING.MIN_TARGET_TEMPERATURE]);
+            await this._applyTargetTemperatureRange(newSettings[SETTING.MIN_TARGET_TEMPERATURE]);
+        }
+
+        // Mirror pending timeout values so the synchronous reconnect below (and
+        // the next no-response schedule) picks up the new values before Homey
+        // has persisted them.
+        const changedTimeouts = TIMEOUT_SETTINGS.filter((key) => changedKeys.includes(key));
+        changedTimeouts.forEach((key) => {
+            this._pendingSettings[key] = newSettings[key];
+        });
+
+        // The client-facing timeouts are only read when the HVAC client is
+        // constructed, so a reconnect is needed to rebuild it with the new
+        // values. The "no_response_reconnect_timeout" is read live on each
+        // schedule and needs no reconnect.
+        if (this._client && changedTimeouts.some((key) => CLIENT_TIMEOUT_SETTINGS.includes(key))) {
+            this.log('[settings]', 'Connection timeout changed. Reconnecting.');
+            this.reconnect();
         }
     }
 
@@ -173,7 +217,7 @@ class GreeHVACDevice extends Homey.Device {
      * @private
      */
     async _applyTargetTemperatureRange(min) {
-        const minTemperature = min ?? this.getSetting('min_target_temperature') ?? DEFAULT_MIN_TARGET_TEMPERATURE;
+        const minTemperature = min ?? this.getSetting(SETTING.MIN_TARGET_TEMPERATURE) ?? DEFAULT_MIN_TARGET_TEMPERATURE;
 
         await this.setCapabilityOptions('target_temperature', {
             min: minTemperature,
@@ -239,12 +283,31 @@ class GreeHVACDevice extends Homey.Device {
         this._client = new HVAC.Client({
             logLevel: 'debug',
             host,
-            pollingInterval: POLLING_INTERVAL,
-            pollingTimeout: POLLING_TIMEOUT,
-            connectTimeout: CONNECT_TIMEOUT,
+            pollingInterval: this._getSetting(SETTING.POLLING_INTERVAL, DEFAULT_POLLING_INTERVAL),
+            pollingTimeout: this._getSetting(SETTING.POLLING_TIMEOUT, DEFAULT_POLLING_TIMEOUT),
+            connectTimeout: this._getSetting(SETTING.CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT),
         });
 
         this._registerClientListeners();
+    }
+
+    /**
+     * Read a device setting, preferring a value pending from onSettings over the
+     * persisted one (see _pendingSettings). Falls back to the given default when
+     * the resolved value is null/undefined, e.g. for devices paired before the
+     * setting existed.
+     *
+     * @param {string} id Setting id
+     * @param {*} [fallback] Value to use when the setting is null/undefined
+     * @returns {*}
+     * @private
+     */
+    _getSetting(id, fallback) {
+        const value = id in this._pendingSettings
+            ? this._pendingSettings[id]
+            : this.getSetting(id);
+
+        return value ?? fallback;
     }
 
     /**
@@ -663,11 +726,13 @@ class GreeHVACDevice extends Homey.Device {
             return;
         }
 
+        const timeout = this._getSetting(SETTING.NO_RESPONSE_RECONNECT_TIMEOUT, DEFAULT_NO_RESPONSE_RECONNECT_TIMEOUT);
+
         this._noResponseReconnectTimeoutRef = this.homey.setTimeout(() => {
             this._noResponseReconnectTimeoutRef = null;
             this.log('[no response]', 'No response for too long. Reconnecting');
             this.reconnect();
-        }, NO_RESPONSE_RECONNECT_TIMEOUT);
+        }, timeout);
     }
 
     /**
@@ -802,16 +867,13 @@ class GreeHVACDevice extends Homey.Device {
     }
 
     /**
-     * Get static IP from the latest settings state.
-     * onSettings runs before Homey stores new settings, so pending values are cached locally.
+     * Get static IP from the latest settings state (pending value included).
      *
      * @returns {string}
      * @private
      */
     _getStaticIpSetting() {
-        const value = this._staticIpSetting !== undefined
-            ? this._staticIpSetting
-            : this.getSetting('static_ip');
+        const value = this._getSetting(SETTING.STATIC_IP);
 
         // The user may have entered the IP with surrounding whitespace
         return typeof value === 'string' ? value.trim() : value;

--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -174,6 +174,19 @@ class GreeHVACDevice extends Homey.Device {
     }
 
     async onSettings({ oldSettings, newSettings, changedKeys }) {
+        // Validate before applying anything: the client sends a status request
+        // every polling_interval and gives up after polling_timeout, so the
+        // timeout must stay below the interval or requests overlap and the
+        // no-response detection becomes unreliable.
+        if (changedKeys.includes(SETTING.POLLING_INTERVAL) || changedKeys.includes(SETTING.POLLING_TIMEOUT)) {
+            const interval = newSettings[SETTING.POLLING_INTERVAL] ?? DEFAULT_POLLING_INTERVAL;
+            const timeout = newSettings[SETTING.POLLING_TIMEOUT] ?? DEFAULT_POLLING_TIMEOUT;
+
+            if (timeout >= interval) {
+                throw new Error(this.homey.__('error.polling_timeout_too_high'));
+            }
+        }
+
         if (changedKeys.includes(SETTING.STATIC_IP) && oldSettings[SETTING.STATIC_IP] !== newSettings[SETTING.STATIC_IP]) {
             if (newSettings[SETTING.STATIC_IP] && !isValidIpv4(newSettings[SETTING.STATIC_IP])) {
                 throw new Error(this.homey.__('error.invalid_static_ip'));

--- a/drivers/gree_cooper_hunter_hvac/driver.compose.json
+++ b/drivers/gree_cooper_hunter_hvac/driver.compose.json
@@ -337,17 +337,17 @@
             "ko": "폴링 시간 초과"
           },
           "hint": {
-            "en": "How long to wait for a status reply before the HVAC is treated as not responding. Increase it for slow or distant devices. Default: 3000 ms.",
-            "nl": "Hoe lang op een statusantwoord wordt gewacht voordat de HVAC als niet-reagerend wordt beschouwd. Verhoog dit voor trage of veraf gelegen apparaten. Standaard: 3000 ms.",
-            "de": "Wie lange auf eine Statusantwort gewartet wird, bevor die Klimaanlage als nicht reagierend gilt. Erhöhe den Wert für langsame oder weit entfernte Geräte. Standard: 3000 ms.",
-            "fr": "Durée d'attente d'une réponse d'état avant de considérer le climatiseur comme ne répondant pas. Augmentez-la pour les appareils lents ou éloignés. Par défaut : 3000 ms.",
-            "it": "Per quanto tempo attendere una risposta di stato prima di considerare il condizionatore non responsivo. Aumentalo per dispositivi lenti o distanti. Predefinito: 3000 ms.",
-            "sv": "Hur länge appen väntar på ett statussvar innan HVAC:en anses inte svara. Öka värdet för långsamma eller avlägsna enheter. Standard: 3000 ms.",
-            "no": "Hvor lenge appen venter på et statussvar før klimaanlegget regnes som at det ikke svarer. Øk verdien for trege eller fjerne enheter. Standard: 3000 ms.",
-            "es": "Cuánto tiempo se espera una respuesta de estado antes de considerar que el HVAC no responde. Auméntalo para dispositivos lentos o lejanos. Predeterminado: 3000 ms.",
-            "da": "Hvor længe der ventes på et statussvar, før HVAC'en betragtes som ikke-svarende. Forøg værdien for langsomme eller fjerne enheder. Standard: 3000 ms.",
-            "pl": "Jak długo czekać na odpowiedź o stanie, zanim klimatyzator zostanie uznany za nieodpowiadający. Zwiększ dla wolnych lub odległych urządzeń. Domyślnie: 3000 ms.",
-            "ko": "HVAC를 응답 없음으로 간주하기 전에 상태 응답을 기다리는 시간입니다. 느리거나 멀리 있는 기기의 경우 값을 늘리세요. 기본값: 3000 ms."
+            "en": "How long to wait for a status reply before the HVAC is treated as not responding. Increase it for slow or distant devices. Must stay below the polling interval. Default: 3000 ms.",
+            "nl": "Hoe lang op een statusantwoord wordt gewacht voordat de HVAC als niet-reagerend wordt beschouwd. Verhoog dit voor trage of veraf gelegen apparaten. Moet lager blijven dan het pollinginterval. Standaard: 3000 ms.",
+            "de": "Wie lange auf eine Statusantwort gewartet wird, bevor die Klimaanlage als nicht reagierend gilt. Erhöhe den Wert für langsame oder weit entfernte Geräte. Muss unter dem Abfrageintervall bleiben. Standard: 3000 ms.",
+            "fr": "Durée d'attente d'une réponse d'état avant de considérer le climatiseur comme ne répondant pas. Augmentez-la pour les appareils lents ou éloignés. Doit rester inférieur à l'intervalle d'interrogation. Par défaut : 3000 ms.",
+            "it": "Per quanto tempo attendere una risposta di stato prima di considerare il condizionatore non responsivo. Aumentalo per dispositivi lenti o distanti. Deve restare inferiore all'intervallo di polling. Predefinito: 3000 ms.",
+            "sv": "Hur länge appen väntar på ett statussvar innan HVAC:en anses inte svara. Öka värdet för långsamma eller avlägsna enheter. Måste hållas under pollningsintervallet. Standard: 3000 ms.",
+            "no": "Hvor lenge appen venter på et statussvar før klimaanlegget regnes som at det ikke svarer. Øk verdien for trege eller fjerne enheter. Må holdes under pollingintervallet. Standard: 3000 ms.",
+            "es": "Cuánto tiempo se espera una respuesta de estado antes de considerar que el HVAC no responde. Auméntalo para dispositivos lentos o lejanos. Debe mantenerse por debajo del intervalo de sondeo. Predeterminado: 3000 ms.",
+            "da": "Hvor længe der ventes på et statussvar, før HVAC'en betragtes som ikke-svarende. Forøg værdien for langsomme eller fjerne enheder. Skal holdes under pollinginterval. Standard: 3000 ms.",
+            "pl": "Jak długo czekać na odpowiedź o stanie, zanim klimatyzator zostanie uznany za nieodpowiadający. Zwiększ dla wolnych lub odległych urządzeń. Musi pozostać poniżej interwału odpytywania. Domyślnie: 3000 ms.",
+            "ko": "HVAC를 응답 없음으로 간주하기 전에 상태 응답을 기다리는 시간입니다. 느리거나 멀리 있는 기기의 경우 값을 늘리세요. 폴링 간격보다 작아야 합니다. 기본값: 3000 ms."
           },
           "value": 3000,
           "min": 500,

--- a/drivers/gree_cooper_hunter_hvac/driver.compose.json
+++ b/drivers/gree_cooper_hunter_hvac/driver.compose.json
@@ -271,17 +271,30 @@
     {
       "type": "group",
       "label": {
-        "en": "Connection",
-        "nl": "Verbinding",
-        "de": "Verbindung",
-        "fr": "Connexion",
-        "it": "Connessione",
-        "sv": "Anslutning",
-        "no": "Tilkobling",
-        "es": "Conexión",
-        "da": "Forbindelse",
-        "pl": "Połączenie",
-        "ko": "연결"
+        "en": "Connection (advanced)",
+        "nl": "Verbinding (geavanceerd)",
+        "de": "Verbindung (erweitert)",
+        "fr": "Connexion (avancé)",
+        "it": "Connessione (avanzato)",
+        "sv": "Anslutning (avancerat)",
+        "no": "Tilkobling (avansert)",
+        "es": "Conexión (avanzado)",
+        "da": "Forbindelse (avanceret)",
+        "pl": "Połączenie (zaawansowane)",
+        "ko": "연결 (고급)"
+      },
+      "hint": {
+        "en": "Advanced settings. The defaults work for most devices — only change them if your HVAC is often shown as disconnected.",
+        "nl": "Geavanceerde instellingen. De standaardwaarden werken voor de meeste apparaten — wijzig ze alleen als je HVAC vaak als niet-verbonden wordt weergegeven.",
+        "de": "Erweiterte Einstellungen. Die Standardwerte funktionieren für die meisten Geräte — ändere sie nur, wenn deine Klimaanlage oft als getrennt angezeigt wird.",
+        "fr": "Réglages avancés. Les valeurs par défaut conviennent à la plupart des appareils — ne les modifiez que si votre climatiseur est souvent affiché comme déconnecté.",
+        "it": "Impostazioni avanzate. I valori predefiniti vanno bene per la maggior parte dei dispositivi — modificale solo se il condizionatore viene spesso mostrato come disconnesso.",
+        "sv": "Avancerade inställningar. Standardvärdena fungerar för de flesta enheter — ändra dem bara om din HVAC ofta visas som frånkopplad.",
+        "no": "Avanserte innstillinger. Standardverdiene fungerer for de fleste enheter — endre dem bare hvis klimaanlegget ofte vises som frakoblet.",
+        "es": "Ajustes avanzados. Los valores predeterminados funcionan para la mayoría de los dispositivos — cámbialos solo si tu HVAC aparece a menudo como desconectado.",
+        "da": "Avancerede indstillinger. Standardværdierne fungerer for de fleste enheder — ret dem kun, hvis din HVAC ofte vises som afbrudt.",
+        "pl": "Ustawienia zaawansowane. Wartości domyślne działają dla większości urządzeń — zmień je tylko, jeśli Twój klimatyzator jest często pokazywany jako odłączony.",
+        "ko": "고급 설정입니다. 기본값은 대부분의 기기에서 작동합니다 — HVAC가 자주 연결 끊김으로 표시되는 경우에만 변경하세요."
       },
       "children": [
         {

--- a/drivers/gree_cooper_hunter_hvac/driver.compose.json
+++ b/drivers/gree_cooper_hunter_hvac/driver.compose.json
@@ -283,19 +283,6 @@
         "pl": "Połączenie (zaawansowane)",
         "ko": "연결 (고급)"
       },
-      "hint": {
-        "en": "Advanced settings. The defaults work for most devices — only change them if your HVAC is often shown as disconnected.",
-        "nl": "Geavanceerde instellingen. De standaardwaarden werken voor de meeste apparaten — wijzig ze alleen als je HVAC vaak als niet-verbonden wordt weergegeven.",
-        "de": "Erweiterte Einstellungen. Die Standardwerte funktionieren für die meisten Geräte — ändere sie nur, wenn deine Klimaanlage oft als getrennt angezeigt wird.",
-        "fr": "Réglages avancés. Les valeurs par défaut conviennent à la plupart des appareils — ne les modifiez que si votre climatiseur est souvent affiché comme déconnecté.",
-        "it": "Impostazioni avanzate. I valori predefiniti vanno bene per la maggior parte dei dispositivi — modificale solo se il condizionatore viene spesso mostrato come disconnesso.",
-        "sv": "Avancerade inställningar. Standardvärdena fungerar för de flesta enheter — ändra dem bara om din HVAC ofta visas som frånkopplad.",
-        "no": "Avanserte innstillinger. Standardverdiene fungerer for de fleste enheter — endre dem bare hvis klimaanlegget ofte vises som frakoblet.",
-        "es": "Ajustes avanzados. Los valores predeterminados funcionan para la mayoría de los dispositivos — cámbialos solo si tu HVAC aparece a menudo como desconectado.",
-        "da": "Avancerede indstillinger. Standardværdierne fungerer for de fleste enheder — ret dem kun, hvis din HVAC ofte vises som afbrudt.",
-        "pl": "Ustawienia zaawansowane. Wartości domyślne działają dla większości urządzeń — zmień je tylko, jeśli Twój klimatyzator jest często pokazywany jako odłączony.",
-        "ko": "고급 설정입니다. 기본값은 대부분의 기기에서 작동합니다 — HVAC가 자주 연결 끊김으로 표시되는 경우에만 변경하세요."
-      },
       "children": [
         {
           "id": "polling_interval",

--- a/drivers/gree_cooper_hunter_hvac/driver.compose.json
+++ b/drivers/gree_cooper_hunter_hvac/driver.compose.json
@@ -267,6 +267,168 @@
           }
         }
       ]
+    },
+    {
+      "type": "group",
+      "label": {
+        "en": "Connection",
+        "nl": "Verbinding",
+        "de": "Verbindung",
+        "fr": "Connexion",
+        "it": "Connessione",
+        "sv": "Anslutning",
+        "no": "Tilkobling",
+        "es": "Conexión",
+        "da": "Forbindelse",
+        "pl": "Połączenie",
+        "ko": "연결"
+      },
+      "children": [
+        {
+          "id": "polling_interval",
+          "type": "number",
+          "label": {
+            "en": "Polling interval",
+            "nl": "Pollinginterval",
+            "de": "Abfrageintervall",
+            "fr": "Intervalle d'interrogation",
+            "it": "Intervallo di polling",
+            "sv": "Pollningsintervall",
+            "no": "Pollingintervall",
+            "es": "Intervalo de sondeo",
+            "da": "Pollinginterval",
+            "pl": "Interwał odpytywania",
+            "ko": "폴링 간격"
+          },
+          "hint": {
+            "en": "How often the app asks the HVAC for its current status. Increase it if the device is often shown as disconnected. Default: 3500 ms.",
+            "nl": "Hoe vaak de app de huidige status van de HVAC opvraagt. Verhoog dit als het apparaat vaak als niet-verbonden wordt weergegeven. Standaard: 3500 ms.",
+            "de": "Wie oft die App den aktuellen Status der Klimaanlage abfragt. Erhöhe den Wert, wenn das Gerät oft als getrennt angezeigt wird. Standard: 3500 ms.",
+            "fr": "Fréquence à laquelle l'application demande l'état actuel du climatiseur. Augmentez-la si l'appareil est souvent affiché comme déconnecté. Par défaut : 3500 ms.",
+            "it": "Con quale frequenza l'app richiede lo stato attuale del condizionatore. Aumentalo se il dispositivo viene spesso mostrato come disconnesso. Predefinito: 3500 ms.",
+            "sv": "Hur ofta appen frågar HVAC:en om dess aktuella status. Öka värdet om enheten ofta visas som frånkopplad. Standard: 3500 ms.",
+            "no": "Hvor ofte appen spør klimaanlegget om gjeldende status. Øk verdien hvis enheten ofte vises som frakoblet. Standard: 3500 ms.",
+            "es": "Con qué frecuencia la app solicita el estado actual del HVAC. Auméntalo si el dispositivo aparece a menudo como desconectado. Predeterminado: 3500 ms.",
+            "da": "Hvor ofte appen beder HVAC'en om dens aktuelle status. Forøg værdien, hvis enheden ofte vises som afbrudt. Standard: 3500 ms.",
+            "pl": "Jak często aplikacja odpytuje klimatyzator o bieżący stan. Zwiększ tę wartość, jeśli urządzenie często pokazywane jest jako odłączone. Domyślnie: 3500 ms.",
+            "ko": "앱이 HVAC에 현재 상태를 요청하는 빈도입니다. 기기가 자주 연결 끊김으로 표시되면 값을 늘리세요. 기본값: 3500 ms."
+          },
+          "value": 3500,
+          "min": 1000,
+          "step": 100,
+          "units": {
+            "en": "ms"
+          }
+        },
+        {
+          "id": "polling_timeout",
+          "type": "number",
+          "label": {
+            "en": "Polling timeout",
+            "nl": "Pollingtime-out",
+            "de": "Abfrage-Timeout",
+            "fr": "Délai d'interrogation",
+            "it": "Timeout di polling",
+            "sv": "Pollningstimeout",
+            "no": "Polling-tidsavbrudd",
+            "es": "Tiempo de espera de sondeo",
+            "da": "Polling-timeout",
+            "pl": "Limit czasu odpytywania",
+            "ko": "폴링 시간 초과"
+          },
+          "hint": {
+            "en": "How long to wait for a status reply before the HVAC is treated as not responding. Increase it for slow or distant devices. Default: 3000 ms.",
+            "nl": "Hoe lang op een statusantwoord wordt gewacht voordat de HVAC als niet-reagerend wordt beschouwd. Verhoog dit voor trage of veraf gelegen apparaten. Standaard: 3000 ms.",
+            "de": "Wie lange auf eine Statusantwort gewartet wird, bevor die Klimaanlage als nicht reagierend gilt. Erhöhe den Wert für langsame oder weit entfernte Geräte. Standard: 3000 ms.",
+            "fr": "Durée d'attente d'une réponse d'état avant de considérer le climatiseur comme ne répondant pas. Augmentez-la pour les appareils lents ou éloignés. Par défaut : 3000 ms.",
+            "it": "Per quanto tempo attendere una risposta di stato prima di considerare il condizionatore non responsivo. Aumentalo per dispositivi lenti o distanti. Predefinito: 3000 ms.",
+            "sv": "Hur länge appen väntar på ett statussvar innan HVAC:en anses inte svara. Öka värdet för långsamma eller avlägsna enheter. Standard: 3000 ms.",
+            "no": "Hvor lenge appen venter på et statussvar før klimaanlegget regnes som at det ikke svarer. Øk verdien for trege eller fjerne enheter. Standard: 3000 ms.",
+            "es": "Cuánto tiempo se espera una respuesta de estado antes de considerar que el HVAC no responde. Auméntalo para dispositivos lentos o lejanos. Predeterminado: 3000 ms.",
+            "da": "Hvor længe der ventes på et statussvar, før HVAC'en betragtes som ikke-svarende. Forøg værdien for langsomme eller fjerne enheder. Standard: 3000 ms.",
+            "pl": "Jak długo czekać na odpowiedź o stanie, zanim klimatyzator zostanie uznany za nieodpowiadający. Zwiększ dla wolnych lub odległych urządzeń. Domyślnie: 3000 ms.",
+            "ko": "HVAC를 응답 없음으로 간주하기 전에 상태 응답을 기다리는 시간입니다. 느리거나 멀리 있는 기기의 경우 값을 늘리세요. 기본값: 3000 ms."
+          },
+          "value": 3000,
+          "min": 500,
+          "step": 100,
+          "units": {
+            "en": "ms"
+          }
+        },
+        {
+          "id": "connect_timeout",
+          "type": "number",
+          "label": {
+            "en": "Connection timeout",
+            "nl": "Verbindingstime-out",
+            "de": "Verbindungs-Timeout",
+            "fr": "Délai de connexion",
+            "it": "Timeout di connessione",
+            "sv": "Anslutningstimeout",
+            "no": "Tilkoblingstidsavbrudd",
+            "es": "Tiempo de espera de conexión",
+            "da": "Forbindelsestimeout",
+            "pl": "Limit czasu połączenia",
+            "ko": "연결 시간 초과"
+          },
+          "hint": {
+            "en": "How long to wait when establishing a connection to the HVAC before retrying. Default: 5000 ms.",
+            "nl": "Hoe lang wordt gewacht bij het tot stand brengen van een verbinding met de HVAC voordat opnieuw wordt geprobeerd. Standaard: 5000 ms.",
+            "de": "Wie lange beim Aufbau einer Verbindung zur Klimaanlage gewartet wird, bevor ein neuer Versuch erfolgt. Standard: 5000 ms.",
+            "fr": "Durée d'attente lors de l'établissement d'une connexion au climatiseur avant de réessayer. Par défaut : 5000 ms.",
+            "it": "Per quanto tempo attendere durante l'instaurazione di una connessione al condizionatore prima di riprovare. Predefinito: 5000 ms.",
+            "sv": "Hur länge appen väntar när en anslutning till HVAC:en upprättas innan den försöker igen. Standard: 5000 ms.",
+            "no": "Hvor lenge appen venter når en tilkobling til klimaanlegget opprettes før den prøver igjen. Standard: 5000 ms.",
+            "es": "Cuánto tiempo se espera al establecer una conexión con el HVAC antes de reintentar. Predeterminado: 5000 ms.",
+            "da": "Hvor længe der ventes ved oprettelse af en forbindelse til HVAC'en, før der forsøges igen. Standard: 5000 ms.",
+            "pl": "Jak długo czekać podczas nawiązywania połączenia z klimatyzatorem przed ponowną próbą. Domyślnie: 5000 ms.",
+            "ko": "HVAC에 연결을 설정할 때 다시 시도하기 전에 기다리는 시간입니다. 기본값: 5000 ms."
+          },
+          "value": 5000,
+          "min": 1000,
+          "step": 100,
+          "units": {
+            "en": "ms"
+          }
+        },
+        {
+          "id": "no_response_reconnect_timeout",
+          "type": "number",
+          "label": {
+            "en": "Reconnect after no response",
+            "nl": "Opnieuw verbinden na geen reactie",
+            "de": "Erneut verbinden nach keiner Antwort",
+            "fr": "Reconnexion après absence de réponse",
+            "it": "Riconnessione dopo nessuna risposta",
+            "sv": "Återanslut efter uteblivet svar",
+            "no": "Koble til på nytt etter manglende svar",
+            "es": "Reconectar tras falta de respuesta",
+            "da": "Genopret forbindelse efter manglende svar",
+            "pl": "Ponowne łączenie po braku odpowiedzi",
+            "ko": "응답 없을 때 재연결"
+          },
+          "hint": {
+            "en": "How long the HVAC may stay unresponsive before the app drops the connection and restarts discovery (helps recover when the device changes its IP address). Default: 60000 ms.",
+            "nl": "Hoe lang de HVAC niet mag reageren voordat de app de verbinding verbreekt en de detectie herstart (helpt bij herstel wanneer het apparaat zijn IP-adres wijzigt). Standaard: 60000 ms.",
+            "de": "Wie lange die Klimaanlage nicht reagieren darf, bevor die App die Verbindung trennt und die Erkennung neu startet (hilft bei der Wiederherstellung, wenn das Gerät seine IP-Adresse ändert). Standard: 60000 ms.",
+            "fr": "Durée pendant laquelle le climatiseur peut rester sans réponse avant que l'application ne coupe la connexion et relance la détection (utile lorsque l'appareil change d'adresse IP). Par défaut : 60000 ms.",
+            "it": "Per quanto tempo il condizionatore può restare non responsivo prima che l'app interrompa la connessione e riavvii il rilevamento (aiuta il ripristino quando il dispositivo cambia indirizzo IP). Predefinito: 60000 ms.",
+            "sv": "Hur länge HVAC:en får vara oåtkomlig innan appen bryter anslutningen och startar om identifieringen (hjälper till att återställa när enheten byter IP-adress). Standard: 60000 ms.",
+            "no": "Hvor lenge klimaanlegget kan være uten respons før appen bryter tilkoblingen og starter oppdagelsen på nytt (hjelper med gjenoppretting når enheten endrer IP-adresse). Standard: 60000 ms.",
+            "es": "Cuánto tiempo puede el HVAC permanecer sin responder antes de que la app corte la conexión y reinicie la detección (ayuda a recuperarse cuando el dispositivo cambia su dirección IP). Predeterminado: 60000 ms.",
+            "da": "Hvor længe HVAC'en må være uden svar, før appen afbryder forbindelsen og genstarter registreringen (hjælper med at genoprette, når enheden ændrer sin IP-adresse). Standard: 60000 ms.",
+            "pl": "Jak długo klimatyzator może nie odpowiadać, zanim aplikacja rozłączy połączenie i ponownie uruchomi wykrywanie (pomaga w odzyskiwaniu, gdy urządzenie zmienia adres IP). Domyślnie: 60000 ms.",
+            "ko": "HVAC가 응답하지 않는 상태로 있을 수 있는 시간으로, 이후 앱이 연결을 끊고 검색을 다시 시작합니다(기기가 IP 주소를 변경할 때 복구에 도움). 기본값: 60000 ms."
+          },
+          "value": 60000,
+          "min": 10000,
+          "step": 1000,
+          "units": {
+            "en": "ms"
+          }
+        }
+      ]
     }
   ],
   "images": {

--- a/locales/da.json
+++ b/locales/da.json
@@ -17,7 +17,8 @@
     "error": {
         "offline": "Din HVAC gik offline. Forsøger at genoprette forbindelsen...",
         "not_connected": "HVAC er ikke tilsluttet. Ændringen kunne ikke anvendes.",
-        "invalid_static_ip": "Ugyldig IP-adresse. Indtast en gyldig IPv4-adresse, eller lad feltet være tomt for at bruge automatisk registrering."
+        "invalid_static_ip": "Ugyldig IP-adresse. Indtast en gyldig IPv4-adresse, eller lad feltet være tomt for at bruge automatisk registrering.",
+        "polling_timeout_too_high": "Polling-timeout skal være lavere end pollinginterval."
     },
     "deprecated": {
         "notification": "Du bruger et forældet Gree-flowkort (__card__). Det vil blive fjernet i en fremtidig opdatering — skift til Homeys indbyggede flowkort til termostattilstand.",

--- a/locales/de.json
+++ b/locales/de.json
@@ -17,7 +17,8 @@
     "error": {
         "offline": "Deine Klimaanlage ist offline gegangen. Es wird versucht, die Verbindung wiederherzustellen...",
         "not_connected": "Die Klimaanlage ist nicht verbunden. Die Änderung konnte nicht angewendet werden.",
-        "invalid_static_ip": "Ungültige IP-Adresse. Gib eine gültige IPv4-Adresse ein oder lass das Feld leer, um die automatische Erkennung zu verwenden."
+        "invalid_static_ip": "Ungültige IP-Adresse. Gib eine gültige IPv4-Adresse ein oder lass das Feld leer, um die automatische Erkennung zu verwenden.",
+        "polling_timeout_too_high": "Das Abfrage-Timeout muss kleiner als das Abfrageintervall sein."
     },
     "deprecated": {
         "notification": "Sie verwenden eine veraltete Gree-Flow-Karte (__card__). Sie wird in einem zukünftigen Update entfernt – bitte wechseln Sie zu den integrierten Thermostatmodus-Flow-Karten von Homey.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -17,7 +17,8 @@
     "error": {
         "offline": "Your HVAC went offline. Trying to reconnect...",
         "not_connected": "The HVAC is not connected. The change could not be applied.",
-        "invalid_static_ip": "Invalid IP address. Enter a valid IPv4 address or leave the field empty to use auto-discovery."
+        "invalid_static_ip": "Invalid IP address. Enter a valid IPv4 address or leave the field empty to use auto-discovery.",
+        "polling_timeout_too_high": "Polling timeout must be lower than the polling interval."
     },
     "deprecated": {
         "notification": "You are using a deprecated Gree flow card (__card__). It will be removed in a future update — please switch to Homey's built-in thermostat mode flow cards.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -17,7 +17,8 @@
     "error": {
         "offline": "Tu HVAC se ha desconectado. Intentando reconectar...",
         "not_connected": "El HVAC no está conectado. No se pudo aplicar el cambio.",
-        "invalid_static_ip": "Dirección IP no válida. Introduce una dirección IPv4 válida o deja el campo vacío para usar la detección automática."
+        "invalid_static_ip": "Dirección IP no válida. Introduce una dirección IPv4 válida o deja el campo vacío para usar la detección automática.",
+        "polling_timeout_too_high": "El tiempo de espera de sondeo debe ser inferior al intervalo de sondeo."
     },
     "deprecated": {
         "notification": "Estás usando una tarjeta de flujo de Gree obsoleta (__card__). Se eliminará en una futura actualización; cambia a las tarjetas de flujo del modo termostato integradas en Homey.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -17,7 +17,8 @@
     "error": {
         "offline": "Ton HVAC est passé hors ligne. Tentative de reconnexion...",
         "not_connected": "Le HVAC n’est pas connecté. La modification n’a pas pu être appliquée.",
-        "invalid_static_ip": "Adresse IP invalide. Saisis une adresse IPv4 valide ou laisse le champ vide pour utiliser la détection automatique."
+        "invalid_static_ip": "Adresse IP invalide. Saisis une adresse IPv4 valide ou laisse le champ vide pour utiliser la détection automatique.",
+        "polling_timeout_too_high": "Le délai d'interrogation doit être inférieur à l'intervalle d'interrogation."
     },
     "deprecated": {
         "notification": "Vous utilisez une carte de flux Gree obsolète (__card__). Elle sera supprimée dans une future mise à jour — veuillez passer aux cartes de flux du mode thermostat intégrées à Homey.",

--- a/locales/it.json
+++ b/locales/it.json
@@ -17,7 +17,8 @@
     "error": {
         "offline": "Il tuo condizionatore è andato offline. Tentativo di riconnessione in corso...",
         "not_connected": "Il condizionatore non è connesso. La modifica non è stata applicata.",
-        "invalid_static_ip": "Indirizzo IP non valido. Inserisci un indirizzo IPv4 valido o lascia vuoto il campo per usare il rilevamento automatico."
+        "invalid_static_ip": "Indirizzo IP non valido. Inserisci un indirizzo IPv4 valido o lascia vuoto il campo per usare il rilevamento automatico.",
+        "polling_timeout_too_high": "Il timeout di polling deve essere inferiore all'intervallo di polling."
     },
     "deprecated": {
         "notification": "Stai usando una scheda di flusso Gree obsoleta (__card__). Verrà rimossa in un futuro aggiornamento — passa alle schede di flusso della modalità termostato integrate in Homey.",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -17,7 +17,8 @@
     "error": {
         "offline": "HVAC가 오프라인 상태가 되었습니다. 다시 연결하는 중...",
         "not_connected": "HVAC가 연결되어 있지 않습니다. 변경 사항을 적용할 수 없습니다.",
-        "invalid_static_ip": "잘못된 IP 주소입니다. 유효한 IPv4 주소를 입력하거나 자동 검색을 사용하려면 필드를 비워 두세요."
+        "invalid_static_ip": "잘못된 IP 주소입니다. 유효한 IPv4 주소를 입력하거나 자동 검색을 사용하려면 필드를 비워 두세요.",
+        "polling_timeout_too_high": "폴링 시간 초과는 폴링 간격보다 작아야 합니다."
     },
     "deprecated": {
         "notification": "더 이상 사용되지 않는 Gree 플로우 카드(__card__)를 사용하고 있습니다. 향후 업데이트에서 제거될 예정이니 Homey의 기본 온도 조절기 모드 플로우 카드로 전환하세요.",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -17,7 +17,8 @@
     "error": {
         "offline": "Je Airco is offline gegaan. Aan het proberen opnieuw te verbinden...",
         "not_connected": "De airco is niet verbonden. De wijziging kon niet worden toegepast.",
-        "invalid_static_ip": "Ongeldig IP-adres. Voer een geldig IPv4-adres in of laat het veld leeg om automatische detectie te gebruiken."
+        "invalid_static_ip": "Ongeldig IP-adres. Voer een geldig IPv4-adres in of laat het veld leeg om automatische detectie te gebruiken.",
+        "polling_timeout_too_high": "De pollingtime-out moet lager zijn dan het pollinginterval."
     },
     "deprecated": {
         "notification": "Je gebruikt een verouderde Gree-flowkaart (__card__). Deze wordt in een toekomstige update verwijderd — schakel over naar de ingebouwde thermostaatmodus-flowkaarten van Homey.",

--- a/locales/no.json
+++ b/locales/no.json
@@ -17,7 +17,8 @@
     "error": {
         "offline": "Klimaanlegget ditt ble frakoblet. Prøver å koble til på nytt...",
         "not_connected": "Klimaanlegget er ikke tilkoblet. Endringen kunne ikke utføres.",
-        "invalid_static_ip": "Ugyldig IP-adresse. Angi en gyldig IPv4-adresse eller la feltet stå tomt for å bruke automatisk oppdagelse."
+        "invalid_static_ip": "Ugyldig IP-adresse. Angi en gyldig IPv4-adresse eller la feltet stå tomt for å bruke automatisk oppdagelse.",
+        "polling_timeout_too_high": "Polling-tidsavbruddet må være lavere enn pollingintervallet."
     },
     "deprecated": {
         "notification": "Du bruker et utdatert Gree-flytkort (__card__). Det vil bli fjernet i en fremtidig oppdatering — bytt til Homeys innebygde flytkort for termostatmodus.",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -17,7 +17,8 @@
     "error": {
         "offline": "Twój klimatyzator przeszedł w tryb offline. Próba ponownego połączenia...",
         "not_connected": "Klimatyzator nie jest połączony. Nie można zastosować zmiany.",
-        "invalid_static_ip": "Nieprawidłowy adres IP. Wprowadź prawidłowy adres IPv4 lub pozostaw pole puste, aby użyć automatycznego wykrywania."
+        "invalid_static_ip": "Nieprawidłowy adres IP. Wprowadź prawidłowy adres IPv4 lub pozostaw pole puste, aby użyć automatycznego wykrywania.",
+        "polling_timeout_too_high": "Limit czasu odpytywania musi być niższy niż interwał odpytywania."
     },
     "deprecated": {
         "notification": "Używasz przestarzałej karty przepływu Gree (__card__). Zostanie ona usunięta w przyszłej aktualizacji — przełącz się na wbudowane karty przepływu trybu termostatu w Homey.",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -17,7 +17,8 @@
     "error": {
         "offline": "Din HVAC har kopplats från. Försöker återansluta...",
         "not_connected": "HVAC är inte ansluten. Ändringen kunde inte tillämpas.",
-        "invalid_static_ip": "Ogiltig IP-adress. Ange en giltig IPv4-adress eller lämna fältet tomt för att använda automatisk identifiering."
+        "invalid_static_ip": "Ogiltig IP-adress. Ange en giltig IPv4-adress eller lämna fältet tomt för att använda automatisk identifiering.",
+        "polling_timeout_too_high": "Pollningstimeout måste vara lägre än pollningsintervallet."
     },
     "deprecated": {
         "notification": "Du använder ett föråldrat Gree-flödeskort (__card__). Det kommer att tas bort i en framtida uppdatering — byt till Homeys inbyggda flödeskort för termostatläge.",

--- a/test/device.findDevices.test.js
+++ b/test/device.findDevices.test.js
@@ -115,7 +115,7 @@ describe('GreeHVACDevice._findDevices()', () => {
 
         expect(device.reconnect).toHaveBeenCalledTimes(1);
         expect(device.reconnect).toHaveBeenCalledWith();
-        expect(device._staticIpSetting).toBe('192.168.1.51');
+        expect(device._pendingSettings.static_ip).toBe('192.168.1.51');
     });
 
     test('rejects an invalid static IP and does not reconnect', async () => {
@@ -129,7 +129,7 @@ describe('GreeHVACDevice._findDevices()', () => {
         })).rejects.toThrow('error.invalid_static_ip');
 
         expect(device.reconnect).not.toHaveBeenCalled();
-        expect(device._staticIpSetting).toBeUndefined();
+        expect(device._pendingSettings.static_ip).toBeUndefined();
     });
 
     test('applies the target temperature range when the minimum setting changes', async () => {
@@ -206,7 +206,7 @@ describe('GreeHVACDevice._findDevices()', () => {
 
         expect(device.reconnect).toHaveBeenCalledTimes(1);
         expect(device.reconnect).toHaveBeenCalledWith();
-        expect(device._staticIpSetting).toBe('');
+        expect(device._pendingSettings.static_ip).toBe('');
     });
 
     test('reconnect starts lookup', () => {
@@ -224,7 +224,7 @@ describe('GreeHVACDevice._findDevices()', () => {
 
     test('find devices uses pending empty static IP setting instead of old stored setting', () => {
         device.getSetting = jest.fn(() => '192.168.1.50');
-        device._staticIpSetting = '';
+        device._pendingSettings.static_ip = '';
         mockFinder.hvacs = [
             { message: { mac: 'aabb' }, remoteInfo: { address: '10.0.0.5' } },
         ];

--- a/test/device.noResponseReconnect.test.js
+++ b/test/device.noResponseReconnect.test.js
@@ -31,6 +31,7 @@ describe('GreeHVACDevice reconnect on prolonged no response', () => {
         };
         device.log = jest.fn();
         device.getAvailable = jest.fn(() => true);
+        device.getSetting = jest.fn(() => undefined);
         device._markOffline = jest.fn();
         device.reconnect = jest.fn();
     });

--- a/test/device.timeoutSettings.test.js
+++ b/test/device.timeoutSettings.test.js
@@ -1,0 +1,175 @@
+'use strict';
+
+describe('GreeHVACDevice configurable timeouts', () => {
+    let GreeHVACDevice;
+    let ClientMock;
+    let device;
+
+    beforeEach(() => {
+        jest.resetModules();
+
+        ClientMock = jest.fn().mockImplementation(() => ({}));
+
+        jest.doMock('../drivers/gree_cooper_hunter_hvac/network/finder', () => ({ hvacs: [] }));
+
+        jest.doMock('gree-hvac-client', () => ({
+            Client: ClientMock,
+            PROPERTY: { power: 'power', mode: 'mode', temperature: 'temperature' },
+            VALUE: { power: { on: 'on', off: 'off' } },
+        }));
+
+        jest.doMock('homey', () => ({
+            Device: class Device {
+                log() {}
+                error() {}
+            },
+        }));
+
+        GreeHVACDevice = require('../drivers/gree_cooper_hunter_hvac/device');
+
+        device = new GreeHVACDevice();
+        device.log = jest.fn();
+        device.reconnect = jest.fn();
+        device._registerClientListeners = jest.fn();
+    });
+
+    describe('_connectToHost', () => {
+        test('passes the configured timeouts to the HVAC client', () => {
+            const settings = {
+                polling_interval: 8000,
+                polling_timeout: 6000,
+                connect_timeout: 9000,
+            };
+            device.getSetting = jest.fn((id) => settings[id]);
+
+            device._connectToHost('10.0.0.5');
+
+            expect(ClientMock).toHaveBeenCalledTimes(1);
+            expect(ClientMock).toHaveBeenCalledWith(expect.objectContaining({
+                host: '10.0.0.5',
+                pollingInterval: 8000,
+                pollingTimeout: 6000,
+                connectTimeout: 9000,
+            }));
+        });
+
+        test('falls back to the default timeouts when the settings are unset', () => {
+            device.getSetting = jest.fn(() => undefined);
+
+            device._connectToHost('10.0.0.5');
+
+            expect(ClientMock).toHaveBeenCalledWith(expect.objectContaining({
+                pollingInterval: 3500,
+                pollingTimeout: 3000,
+                connectTimeout: 5000,
+            }));
+        });
+    });
+
+    describe('_scheduleNoResponseReconnect', () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+            device.homey = {
+                setTimeout: (fn, ms) => setTimeout(fn, ms),
+                clearTimeout: (ref) => clearTimeout(ref),
+            };
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        test('uses the configured no-response reconnect timeout', () => {
+            device.getSetting = jest.fn(() => 20000);
+
+            device._scheduleNoResponseReconnect();
+
+            jest.advanceTimersByTime(19000);
+            expect(device.reconnect).not.toHaveBeenCalled();
+
+            jest.advanceTimersByTime(1000);
+            expect(device.reconnect).toHaveBeenCalledTimes(1);
+        });
+
+        test('falls back to the default no-response reconnect timeout when unset', () => {
+            device.getSetting = jest.fn(() => undefined);
+
+            device._scheduleNoResponseReconnect();
+
+            jest.advanceTimersByTime(60 * 1000);
+            expect(device.reconnect).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('onSettings', () => {
+        beforeEach(() => {
+            device.getSetting = jest.fn(() => undefined);
+        });
+
+        const expectReconnectOnChange = async (key) => {
+            device._client = {};
+
+            await device.onSettings({
+                oldSettings: { [key]: 3000 },
+                newSettings: { [key]: 8000 },
+                changedKeys: [key],
+            });
+
+            expect(device.reconnect).toHaveBeenCalledTimes(1);
+        };
+
+        test('reconnects when polling_interval changes while connected', async () => {
+            await expectReconnectOnChange('polling_interval');
+        });
+
+        test('reconnects when polling_timeout changes while connected', async () => {
+            await expectReconnectOnChange('polling_timeout');
+        });
+
+        test('reconnects when connect_timeout changes while connected', async () => {
+            await expectReconnectOnChange('connect_timeout');
+        });
+
+        test('does not reconnect when a client timeout changes but no client is connected', async () => {
+            device._client = null;
+
+            await device.onSettings({
+                oldSettings: { polling_interval: 3500 },
+                newSettings: { polling_interval: 8000 },
+                changedKeys: ['polling_interval'],
+            });
+
+            expect(device.reconnect).not.toHaveBeenCalled();
+        });
+
+        test('uses the new timeout when reconnecting, before Homey persists it', async () => {
+            // getSetting still returns the OLD value during onSettings
+            device.getSetting = jest.fn(() => 3500);
+            device._client = {};
+            device._registerClientListeners = jest.fn();
+            device.reconnect = jest.fn(() => device._connectToHost('10.0.0.5'));
+
+            await device.onSettings({
+                oldSettings: { polling_interval: 3500 },
+                newSettings: { polling_interval: 9000 },
+                changedKeys: ['polling_interval'],
+            });
+
+            expect(ClientMock).toHaveBeenCalledWith(expect.objectContaining({
+                pollingInterval: 9000,
+            }));
+        });
+
+        test('does not reconnect when only the no-response reconnect timeout changes', async () => {
+            device._client = {};
+
+            await device.onSettings({
+                oldSettings: { no_response_reconnect_timeout: 60000 },
+                newSettings: { no_response_reconnect_timeout: 120000 },
+                changedKeys: ['no_response_reconnect_timeout'],
+            });
+
+            expect(device.reconnect).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/test/device.timeoutSettings.test.js
+++ b/test/device.timeoutSettings.test.js
@@ -104,14 +104,55 @@ describe('GreeHVACDevice configurable timeouts', () => {
     describe('onSettings', () => {
         beforeEach(() => {
             device.getSetting = jest.fn(() => undefined);
+            device.homey = { __: jest.fn((key) => key) };
+        });
+
+        test('rejects a polling timeout that is not below the polling interval', async () => {
+            device._client = {};
+
+            await expect(device.onSettings({
+                oldSettings: { polling_interval: 3500, polling_timeout: 3000 },
+                newSettings: { polling_interval: 3500, polling_timeout: 3500 },
+                changedKeys: ['polling_timeout'],
+            })).rejects.toThrow('error.polling_timeout_too_high');
+
+            expect(device.reconnect).not.toHaveBeenCalled();
+        });
+
+        test('rejects lowering the polling interval to or below the polling timeout', async () => {
+            device._client = {};
+
+            await expect(device.onSettings({
+                oldSettings: { polling_interval: 3500, polling_timeout: 3000 },
+                newSettings: { polling_interval: 2000, polling_timeout: 3000 },
+                changedKeys: ['polling_interval'],
+            })).rejects.toThrow('error.polling_timeout_too_high');
+
+            expect(device.reconnect).not.toHaveBeenCalled();
+        });
+
+        test('accepts a polling timeout below the polling interval', async () => {
+            device._client = {};
+
+            await device.onSettings({
+                oldSettings: { polling_interval: 3500, polling_timeout: 3000 },
+                newSettings: { polling_interval: 3500, polling_timeout: 3400 },
+                changedKeys: ['polling_timeout'],
+            });
+
+            expect(device.reconnect).toHaveBeenCalledTimes(1);
         });
 
         const expectReconnectOnChange = async (key) => {
             device._client = {};
 
+            // A full, internally-valid set (polling_timeout < polling_interval)
+            // so the change under test is what drives the reconnect.
+            const base = { polling_interval: 9000, polling_timeout: 3000, connect_timeout: 5000 };
+
             await device.onSettings({
-                oldSettings: { [key]: 3000 },
-                newSettings: { [key]: 8000 },
+                oldSettings: { ...base, [key]: 1000 },
+                newSettings: base,
                 changedKeys: [key],
             });
 


### PR DESCRIPTION
Closes #95.

## What

Adds a new **Connection** settings group so users can tune the network timeouts per device, preventing slow or intermittently-responding HVACs from being falsely shown as disconnected (from this [community request](https://community.homey.app/t/app-pro-gree-hvac-app/30801/66)).

Four settings (milliseconds), replacing the previously hardcoded constants which now serve as fallback defaults:

| Setting | Default | Effect |
| --- | --- | --- |
| `polling_interval` | 3500 | how often status is polled |
| `polling_timeout` | 3000 | wait before a poll counts as `no_response` (→ offline) |
| `connect_timeout` | 5000 | connection attempt timeout |
| `no_response_reconnect_timeout` | 60000 | how long offline before a full reconnect |

Defaults are intentionally equal to the previous hardcoded values, so existing devices behave identically after upgrade.

## How

- **`driver.compose.json`** — new localized settings group (all 11 locales); `app.json` regenerated via `homey app build`.
- **`device.js`** — the three client-facing timeouts are read in `_connectToHost`; `no_response_reconnect_timeout` is read live in `_scheduleNoResponseReconnect`. Since those three are only read at `Client` construction, `onSettings` triggers a `reconnect()` when any of them changes (not for the no-response one, which is read fresh).
- **Pre-persist handling** — `onSettings` runs before Homey persists the change but triggers a synchronous reconnect, so new values are mirrored in a **unified `_pendingSettings` map** and read through a single `_getSetting(id, fallback)` helper. This replaces the previous ad-hoc `_staticIpSetting` cache, so static-IP and timeout settings now share one mechanism.
- **Guardrail** — the client sends a request every `polling_interval` and gives up after `polling_timeout`, so a timeout `>=` interval makes requests overlap and no-response detection unreliable. `onSettings` rejects such input (before any side effects) with a localized error, and the `polling_timeout` hint documents the constraint.
- Setting ids are centralized in a `SETTING` constant.
- Version bumped `1.1.2` → `1.2.0` with a changelog entry in all 11 locales.

Supersedes the stale draft #97, adapted to the current architecture (settings groups, `reconnect()`, `_connectToHost`) and covering all four timeouts.

## Testing

- `npm test` — ESLint + Jest, **114/114 pass** (`test/device.timeoutSettings.test.js` covers client args, default fallbacks, the pre-persist reconnect value, reconnect-on-change, the no-reconnect case for the no-response timeout, and the timeout-vs-interval validation).
- `homey app validate --level publish` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)