### PR TITLE
Keep an error sink on a disconnected HVAC client

### DIFF
--- a/drivers/gree_cooper_hunter_hvac/device.js
+++ b/drivers/gree_cooper_hunter_hvac/device.js
@@ -871,11 +871,28 @@ class GreeHVACDevice extends Homey.Device {
      */
     _tryToDisconnect() {
         if (this._client) {
-            this._client.removeAllListeners();
+            const client = this._client;
+            this._client = null;
+
+            client.removeAllListeners();
+
+            // The client can outlive disconnect(): its reconnect timer is
+            // rescheduled from _initialize()'s catch block, and a timer whose
+            // reference got overwritten by a concurrent reconnect is never
+            // cleared by disconnect(). Such an orphan keeps firing every
+            // connectTimeout, fails with ClientNotConnectedError because the
+            // socket is gone, and reschedules itself forever. Each iteration
+            // emits 'error'; on an emitter without listeners Node throws that
+            // error from inside a .catch() callback, turning it into an
+            // unhandled rejection (Sentry GREE-HOMEY-8). Keep a sink attached
+            // so a dropped client can only ever be noise in the log.
+            client.on('error', (err) => {
+                this.log('[disconnect]', 'Error from an already disconnected client:', err);
+            });
+
             // disconnect() rejects when the client has no active socket
             // (e.g. in the middle of its own reconnect cycle)
-            this._client.disconnect().catch(this.error);
-            this._client = null;
+            client.disconnect().catch(this.error);
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "gree-hvac-client": "github:apachler/gree-hvac-client#v3.0.6",
+        "gree-hvac-client": "github:aivus/gree-hvac-client#fix/orphaned-reconnect-timer",
         "homey-log": "^2.1.2"
       },
       "devDependencies": {
@@ -6414,7 +6414,7 @@
     },
     "node_modules/gree-hvac-client": {
       "version": "3.0.6",
-      "resolved": "git+ssh://git@github.com/apachler/gree-hvac-client.git#eb447d42fca35f5375382ba5e3fab9311f4a43db",
+      "resolved": "git+ssh://git@github.com/aivus/gree-hvac-client.git#262906caeea02784acdc928b5eaf8d050b8eb2bb",
       "license": "GPL-3.0",
       "dependencies": {
         "clone": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/aivus/com.gree#readme",
   "dependencies": {
-    "gree-hvac-client": "github:apachler/gree-hvac-client#v3.0.6",
+    "gree-hvac-client": "github:aivus/gree-hvac-client#fix/orphaned-reconnect-timer",
     "homey-log": "^2.1.2"
   },
   "devDependencies": {

--- a/test/device.disconnect.test.js
+++ b/test/device.disconnect.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { EventEmitter } = require('events');
+
 describe('GreeHVACDevice._tryToDisconnect()', () => {
     let GreeHVACDevice;
     let device;
@@ -31,6 +33,7 @@ describe('GreeHVACDevice._tryToDisconnect()', () => {
     test('handles disconnect() rejection instead of leaving it unhandled', async () => {
         const rejection = new Error('Client is not connected to the HVAC');
         device._client = {
+            on: jest.fn(),
             removeAllListeners: jest.fn(),
             disconnect: jest.fn().mockRejectedValue(rejection),
         };
@@ -47,6 +50,7 @@ describe('GreeHVACDevice._tryToDisconnect()', () => {
 
     test('removes listeners before disconnecting and clears the client', () => {
         const client = {
+            on: jest.fn(),
             removeAllListeners: jest.fn(),
             disconnect: jest.fn().mockResolvedValue(),
         };
@@ -63,5 +67,66 @@ describe('GreeHVACDevice._tryToDisconnect()', () => {
         device._client = null;
 
         expect(() => device._tryToDisconnect()).not.toThrow();
+    });
+
+    // Regression test for Sentry GREE-HOMEY-8: the HVAC client can keep an
+    // orphaned reconnect timer running after disconnect() and emits 'error' on
+    // every tick. Without a listener, EventEmitter re-throws that error from a
+    // .catch() callback inside the library, which surfaces as an unhandled
+    // rejection every connectTimeout, forever.
+    describe('a dropped client that keeps emitting errors', () => {
+        let client;
+
+        beforeEach(() => {
+            client = new EventEmitter();
+            client.disconnect = jest.fn().mockResolvedValue();
+            jest.spyOn(client, 'removeAllListeners');
+
+            // Listeners the device registers while the client is in use
+            client.on('error', () => {});
+            client.on('update', () => {});
+        });
+
+        test('keeps an error sink attached so late errors cannot become unhandled', () => {
+            device._client = client;
+
+            device._tryToDisconnect();
+
+            expect(client.listenerCount('update')).toBe(0);
+            expect(client.listenerCount('error')).toBe(1);
+
+            const error = new Error('Client is not connected to the HVAC');
+            expect(() => client.emit('error', error)).not.toThrow();
+            expect(device.log).toHaveBeenCalledWith(
+                '[disconnect]',
+                'Error from an already disconnected client:',
+                error,
+            );
+        });
+
+        test('logs non-Error emissions as-is instead of undefined', () => {
+            device._client = client;
+
+            device._tryToDisconnect();
+
+            expect(() => client.emit('error', 'connection lost')).not.toThrow();
+            expect(device.log).toHaveBeenCalledWith(
+                '[disconnect]',
+                'Error from an already disconnected client:',
+                'connection lost',
+            );
+        });
+
+        test('attaches the sink after removing the device listeners', () => {
+            device._client = client;
+
+            device._tryToDisconnect();
+
+            const removeOrder = client.removeAllListeners.mock.invocationCallOrder[0];
+            const disconnectOrder = client.disconnect.mock.invocationCallOrder[0];
+
+            expect(removeOrder).toBeLessThan(disconnectOrder);
+            expect(client.listenerCount('error')).toBe(1);
+        });
     });
 });

--- a/test/device.uninit.test.js
+++ b/test/device.uninit.test.js
@@ -34,6 +34,7 @@ describe('GreeHVACDevice cleanup on removal and app shutdown', () => {
 
     function setupResources() {
         const client = {
+            on: jest.fn(),
             removeAllListeners: jest.fn(),
             disconnect: jest.fn().mockResolvedValue(),
         };


### PR DESCRIPTION
Fixes [GREE-HOMEY-8](https://homey-gree.sentry.io/issues/GREE-HOMEY-8).

## The bug

`_tryToDisconnect()` removed every listener and then dropped the client, leaving it as an `EventEmitter` with no `'error'` handler. That is only safe if the client is really finished — and it isn't.

The HVAC client can outlive `disconnect()`. Its reconnect timer is rescheduled from `_initialize()`'s catch block, and a timer whose reference was overwritten by a concurrent reconnect is never cleared by `disconnect()`. Such an orphan keeps firing every `connectTimeout`, fails in `_socketSend()` with `ClientNotConnectedError` because the socket is gone, and reschedules itself forever.

Each iteration emits `'error'`. On an emitter without listeners Node throws it — from inside the library's own `.catch()` callback — so every tick became an unhandled rejection:

```
ClientNotConnectedError: Client is not connected to the HVAC
    at gree-hvac-client/src/client.js:463:24   reject(new ClientNotConnectedError())
    at Client._socketSend (client.js:443:16)
    at Client._initialize (client.js:238:24)
    at Timeout._onTimeout (client.js:261:22)
```

Sentry collected ~11,600 of these from two installs (app 1.1.1 and 1.2.0), arriving **exactly every 5000 ms** — the `DEFAULT_CONNECT_TIMEOUT` those devices ran with. That cadence is what identified the cause. No user-visible breakage: the app keeps running, so this is wasted timers, UDP traffic and Sentry quota rather than a crash.

## The fix

Drop the reference first, then attach a logging sink for `'error'` after stripping the device listeners. A dropped client can now only ever be noise in the log.

## Why this stays even after the library is fixed

The timer leak itself is fixed upstream in apachler/gree-hvac-client#18 (second commit here points the dependency at that branch; move it back to a release tag once merged and released). The sink is still worth keeping:

- It does not cover only the reconnect loop. The polling wrapper at `client.js:669` is `this._requestStatus().catch(error => this.emit('error', error))` — a status poll in flight when we disconnect rejects afterwards and hits the same path. Against the **patched** library that still produces 1 unhandled rejection without the sink, and 0 with it. `reconnect()` runs on every 60 s no-response, so this isn't rare.
- `removeAllListeners()` on an emitter we don't own is inherently unsafe: any `'error'` afterwards becomes a throw. The sink makes `_tryToDisconnect()` robust against future library behaviour, not just this bug.
- It's the only thing that helps installs already on 1.1.1 / 1.2.0, before an upstream release can ship.

## Tests

`test/device.disconnect.test.js` gains a regression block that uses a real `EventEmitter` as the fake client, so `emit('error')` genuinely throws when unlistened — the tests fail against the old code. Covers: the sink survives listener removal, non-`Error` emissions log as-is, and the sink is attached after the device listeners are removed. The plain-object client mocks in `device.disconnect` / `device.uninit` gained `on: jest.fn()`.

`npm test` (ESLint + Jest): 22 suites, 117 tests, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)